### PR TITLE
Remove "None" from output and show stderr on failed start

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -181,6 +181,7 @@ class NodeStartCmd(Cmd):
         except NodeError as e:
             print_(str(e), file=sys.stderr)
             print_("Standard error output is:", file=sys.stderr)
+            e.process.stderr_file.seek(0)
             for line in e.process.stderr_file.readlines():
                 print_(line.rstrip('\n'), file=sys.stderr)
             exit(1)


### PR DESCRIPTION
When `ccm node start --verbose` fails, the stderr output is lost; in addition, `None` is printed:

```
ccm node1 start --verbose

None
Error starting node node1
Standard error output is:
```

With this patch, we see:

```
ccm node1 start --verbose

Error starting node node1
Standard error output is:
intx ThreadPriorityPolicy=42 is outside the allowed range [ 0 ... 1 ]
Improperly specified VM option 'ThreadPriorityPolicy=42'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

(which showed my problem to be an installed JDK 9 in the path combined with no set JAVA_HOME)