### PR TITLE
Decode output of external tool subprocess

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -2099,6 +2099,8 @@ def _grep_log_for_errors(log):
 
 def handle_external_tool_process(process, cmd_args):
     out, err = process.communicate()
+    if out and isinstance(out, bytes):
+        out = out.decode()
     rc = process.returncode
 
     if rc != 0:


### PR DESCRIPTION
Dtests interacting with external cassandra tools currently fail in Python3 environments, as the output is not decoded before passed to `JSON.loads()`.

Example:
https://builds.apache.org/view/A-D/view/Cassandra/job/Cassandra-devbranch-dtest/494/testReport/offline_tools_test/TestOfflineTools/test_sstabledump/