### PR TITLE
Issue #670: also decode empty stdout and stderr to strings

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -2099,9 +2099,9 @@ def _grep_log_for_errors(log):
 
 def handle_external_tool_process(process, cmd_args):
     out, err = process.communicate()
-    if out and isinstance(out, bytes):
+    if (out is not None) and isinstance(out, bytes):
         out = out.decode()
-    if err and isinstance(err, bytes):
+    if (err is not None) and isinstance(err, bytes):
         err = err.decode()
     rc = process.returncode
 


### PR DESCRIPTION
Addresses Issue #670 to decode empty bytes objects (b'') for stdout and stderr piped from subprocess. Without this change, handle_external_tool_process returns inconsistently typed results - it returns stdout and stderr as strings if they're non-empty, but as bytes if they're empty.