### PR TITLE
Add command to enable DSE's AOSS

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -700,5 +700,5 @@ class Cluster(object):
                     return ret(node=node, matchings=matchings)
             time.sleep(1)
 
-    def wait_for_any_log(self, pattern, timeout, filename='system.log'):
-        return common.wait_for_any_log(self.nodelist(), pattern, timeout, filename=filename)
+    def wait_for_any_log(self, pattern, timeout, filename='system.log', marks=None):
+        return common.wait_for_any_log(self.nodelist(), pattern, timeout, filename=filename, marks=marks)

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -29,6 +29,7 @@ class Cluster(object):
         self.partitioner = partitioner
         self._config_options = {}
         self._dse_config_options = {}
+        self._misc_config_options = {}
         self._environment_variables = {}
         self.__log_level = "INFO"
         self.__path = path
@@ -316,7 +317,7 @@ class Cluster(object):
         tokens.extend(new_tokens)
         return tokens
 
-    def remove(self, node=None):
+    def remove(self, node=None, gently=False):
         if node is not None:
             if node.name not in self.nodes:
                 return
@@ -325,10 +326,10 @@ class Cluster(object):
             if node in self.seeds:
                 self.seeds.remove(node)
             self._update_config()
-            node.stop(gently=False)
+            node.stop(gently=gently)
             self.remove_dir_with_retry(node.get_path())
         else:
-            self.stop(gently=False)
+            self.stop(gently=gently)
             self.remove_dir_with_retry(self.get_path())
 
     # We can race w/shutdown on Windows and get Access is denied attempting to delete node logs.
@@ -572,6 +573,10 @@ class Cluster(object):
         for node in list(self.nodes.values()):
             node.verify(options)
 
+    def enable_aoss(self):
+        common.error("Cannot enable AOSS in C* clusters")
+        exit(1)
+
     def update_log4j(self, new_log4j_config):
         # iterate over all nodes
         for node in self.nodelist():
@@ -597,6 +602,7 @@ class Cluster(object):
             'install_dir': self.__install_dir,
             'config_options': self._config_options,
             'dse_config_options': self._dse_config_options,
+            'misc_config_options' : self._misc_config_options,
             'log_level': self.__log_level,
             'use_vnodes': self.use_vnodes,
             'datadirs': self.data_dir_count,

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -45,6 +45,8 @@ class ClusterFactory():
                 cluster._config_options = data['config_options']
             if 'dse_config_options' in data:
                 cluster._dse_config_options = data['dse_config_options']
+            if 'misc_config_options' in data:
+                cluster._misc_config_options = data['misc_config_options']
             if 'log_level' in data:
                 cluster.__log_level = data['log_level']
             if 'use_vnodes' in data:

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -44,7 +44,8 @@ CLUSTER_CMDS = [
     "checklogerror",
     "showlastlog",
     "jconsole",
-    "setworkload"
+    "setworkload",
+    "enableaoss"
 ]
 
 
@@ -833,3 +834,19 @@ class ClusterSetworkloadCmd(Cmd):
         except common.ArgumentError as e:
             print_(str(e), file=sys.stderr)
             exit(1)
+
+class ClusterEnableaossCmd(Cmd):
+
+    descr_text = "Enable DSE's Always On SparkSQL Server"
+    usage = "usage: ccm enableaoss"
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, load_cluster=True)
+
+    def run(self):
+        try:
+            self.cluster.enable_aoss()
+        except Exception as e:
+            print_(str(e), file=sys.stderr)
+            exit(1)
+

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -764,7 +764,7 @@ def is_intlike(obj):
     raise RuntimeError('Reached end of {}; should not be possible'.format(is_intlike.__name__))
 
 
-def wait_for_any_log(nodes, pattern, timeout, filename='system.log'):
+def wait_for_any_log(nodes, pattern, timeout, filename='system.log', marks=None):
     """
     Look for a pattern in the system.log of any in a given list
     of nodes.
@@ -775,11 +775,14 @@ def wait_for_any_log(nodes, pattern, timeout, filename='system.log'):
                     but a maximum number of attempts. This implies that
                     the all the grepping takes no time at all, so it is
                     somewhat inaccurate, but probably close enough.
+    @param marks A dict of nodes to marks in the file. Keys must match the first param list.
     @return The first node in whose log the pattern was found
     """
+    if marks is None:
+        marks = {}
     for _ in range(timeout):
         for node in nodes:
-            found = node.grep_log(pattern, filename=filename)
+            found = node.grep_log(pattern, filename=filename, from_mark=marks.get(node, None))
             if found:
                 return node
         time.sleep(1)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -302,6 +302,8 @@ def make_dse_env(install_dir, node_path, node_ip):
     if version < '6.0':
         env['SPARK_WORKER_MEMORY'] = os.environ.get('SPARK_WORKER_MEMORY', '1024M')
         env['SPARK_WORKER_CORES'] = os.environ.get('SPARK_WORKER_CORES', '2')
+    else:
+        env['ALWAYSON_SQL_LOG_DIR'] = os.path.join(node_path, 'logs')
     env['DSE_HOME'] = os.path.join(install_dir)
     env['DSE_CONF'] = os.path.join(node_path, 'resources', 'dse', 'conf')
     env['CASSANDRA_HOME'] = os.path.join(install_dir, 'resources', 'cassandra')

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -72,10 +72,13 @@ class DseCluster(Cluster):
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
         if jvm_args is None:
             jvm_args = []
+        marks = {}
+        for node in self.nodelist():
+            marks[node] = node.mark_log()
         started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options, quiet_start=quiet_start, allow_root=allow_root, timeout=180)
         self.start_opscenter()
         if self._misc_config_options.get('enable_aoss', False):
-            self.wait_for_any_log('AlwaysOn SQL started', 600)
+            self.wait_for_any_log('AlwaysOn SQL started', 600, marks=marks)
         return started
 
     def stop(self, wait=True, signal_event=signal.SIGTERM, **kwargs):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -79,7 +79,21 @@ class Node(object):
     Provides interactions to a Cassandra node.
     """
 
-    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, byteman_startup_script=None, derived_cassandra_version=None):
+    def __init__(self,
+                 name,
+                 cluster,
+                 auto_bootstrap,
+                 thrift_interface,
+                 storage_interface,
+                 jmx_port,
+                 remote_debug_port,
+                 initial_token,
+                 save=True,
+                 binary_interface=None,
+                 byteman_port='0',
+                 environment_variables=None,
+                 byteman_startup_script=None,
+                 derived_cassandra_version=None):
         """
         Create a new Node.
           - name: the name for that node
@@ -859,6 +873,9 @@ class Node(object):
     def verify(self, options):
         p = self.verify_process(options=options)
         return handle_external_tool_process(p, ['sstableverify'] + options)
+
+    def enable_aoss(self, thrift_port=10000, web_ui_port=9077):
+        pass
 
     def run_cqlsh_process(self, cmds=None, cqlsh_options=None):
         if cqlsh_options is None:


### PR DESCRIPTION
@kishkaru 

Command enables this on all nodes in the cluster. `ccm remove` behavior is altered slightly, to always stop gracefully if aoss is enabled, otherwise we'll leak spark processes. No DC specific enablement, or disablement of aoss are in this PR. Let me know if you need those.