### PR TITLE
Add ability to configure archive repository locations via ~/.ccm/config

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -269,7 +269,11 @@ def clone_development(git_repo, version, verbose=False, alias=False):
 
 
 def download_dse_version(version, username, password, verbose=False):
-    url = DSE_ARCHIVE % version
+    url = DSE_ARCHIVE
+    if CCM_CONFIG.has_option('repositories', 'dse'):
+        url = CCM_CONFIG.get('repositories', 'dse')
+
+    url = url % version
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
         if username is None:
@@ -295,7 +299,11 @@ def download_dse_version(version, username, password, verbose=False):
 
 
 def download_opscenter_version(version, username, password, target_version, verbose=False):
-    url = OPSC_ARCHIVE % version
+    url = OPSC_ARCHIVE
+    if CCM_CONFIG.has_option('repositories', 'opscenter'):
+        url = CCM_CONFIG.get('repositories', 'opscenter')
+
+    url = url % version
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
         if username is None:
@@ -327,10 +335,14 @@ def download_version(version, url=None, verbose=False, binary=False):
     """
     assert_jdk_valid_for_cassandra_version(version)
 
+    u = ARCHIVE
+    if CCM_CONFIG.has_option('repositories', 'cassandra'):
+        u = CCM_CONFIG.get('repositories', 'cassandra')
+
     if binary:
-        u = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (ARCHIVE, version.split('-')[0], version) if url is None else url
+        u = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (u, version.split('-')[0], version) if url is None else url
     else:
-        u = "%s/%s/apache-cassandra-%s-src.tar.gz" % (ARCHIVE, version.split('-')[0], version) if url is None else url
+        u = "%s/%s/apache-cassandra-%s-src.tar.gz" % (u, version.split('-')[0], version) if url is None else url
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
         __download(u, target, show_progress=verbose)

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -335,17 +335,17 @@ def download_version(version, url=None, verbose=False, binary=False):
     """
     assert_jdk_valid_for_cassandra_version(version)
 
-    u = ARCHIVE
+    archive_url = ARCHIVE
     if CCM_CONFIG.has_option('repositories', 'cassandra'):
-        u = CCM_CONFIG.get('repositories', 'cassandra')
+        archive_url = CCM_CONFIG.get('repositories', 'cassandra')
 
     if binary:
-        u = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (u, version.split('-')[0], version) if url is None else url
+        archive_url = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (archive_url, version.split('-')[0], version) if url is None else url
     else:
-        u = "%s/%s/apache-cassandra-%s-src.tar.gz" % (u, version.split('-')[0], version) if url is None else url
+        archive_url = "%s/%s/apache-cassandra-%s-src.tar.gz" % (archive_url, version.split('-')[0], version) if url is None else url
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
-        __download(u, target, show_progress=verbose)
+        __download(archive_url, target, show_progress=verbose)
         common.info("Extracting {} as version {} ...".format(target, version))
         tar = tarfile.open(target)
         dir = tar.next().name.split("/")[0]  # pylint: disable=all


### PR DESCRIPTION
This adds the capability to override the repository locations for downloading cassandra, DSE, and OpsCenter.   This is useful for situations such as when CCM is used as part of a continuous integration workflow where a local mirror is set up so downloads can be done quickly over the local network.

Repositories can be configured via the `[repositories]` section of the `~/.ccm/config` file which was already defined for git aliases.  For example:

```
[repositories]
cassandra = http://mirror.awesomeco.intranet/apache/cassandra
dse = http://mirror.awesomeco.intranet/tar/dse/dse-%s-bin.tar.gz
opscenter = http://mirror.awesomeco.intranet/tar/opscenter/opscenter-%s.tar.gz
```