### PR TITLE
Use RawConfigParser instead of ConfigParser

### DIFF
--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -53,7 +53,7 @@ class DseCluster(Cluster):
                 dse_credentials_file = creds_file
 
         if dse_credentials_file is not None:
-            parser = ConfigParser.ConfigParser()
+            parser = ConfigParser.RawConfigParser()
             parser.read(dse_credentials_file)
             if parser.has_section('dse_credentials'):
                 if parser.has_option('dse_credentials', 'dse_username'):

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -35,7 +35,7 @@ ARCHIVE = "http://archive.apache.org/dist/cassandra"
 GIT_REPO = "http://git.apache.org/cassandra.git"
 GITHUB_REPO = "https://github.com/apache/cassandra.git"
 GITHUB_TAGS = "https://api.github.com/repos/apache/cassandra/git/refs/tags"
-CCM_CONFIG = ConfigParser.ConfigParser()
+CCM_CONFIG = ConfigParser.RawConfigParser()
 CCM_CONFIG.read(os.path.join(os.path.expanduser("~"), ".ccm", "config"))
 
 


### PR DESCRIPTION
ConfigParser supports string interpolation which I never intended
to be supported and causes issues with Python 3.x when specifying
a dse mirror repository, which expects a format like:

[repositories]
dse = http://myrepo/enterprise/dse-%s-bin.tar.gz

Unfortunately, ConfigParser interpolation is not compatible between
2.x and 3.x as 3.x requires escaping '%', where 2.x does not unescape
'%', so using RawConfigParser seems like the best viable solution.