### PR TITLE
CASSANDRA-9608 upgrade all jvm.options files

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -28,7 +28,7 @@ DSE_CASSANDRA_CONF_DIR = "resources/cassandra/conf"
 OPSCENTER_CONF_DIR = "conf"
 
 CASSANDRA_CONF = "cassandra.yaml"
-JVM_OPTS = "jvm.options"
+JVM_OPTS_PATTERN = "jvm*.options"
 LOG4J_CONF = "log4j-server.properties"
 LOG4J_TOOL_CONF = "log4j-tools.properties"
 LOGBACK_CONF = "logback.xml"


### PR DESCRIPTION
CASSANDRA-9608 splits the `jvm.options` file into multiple files. The patch makes ccm check all those files.