### PR TITLE
Add warning when CASSANDRA_HOME is set in environment

### DIFF
--- a/ccm
+++ b/ccm
@@ -8,6 +8,9 @@ from ccmlib import common
 from ccmlib.cmds import command, cluster_cmds, node_cmds
 from ccmlib.remote import PARAMIKO_IS_AVAILABLE, get_remote_usage, get_remote_options, execute_ccm_remotely
 
+import os
+import warnings
+
 
 def get_command(kind, cmd):
     cmd_name = kind.lower().capitalize() + cmd.lower().capitalize() + "Cmd"
@@ -91,6 +94,9 @@ else:
     node = arg1
     cmd = sys.argv[2]
     cmd_args = [node] + sys.argv[3:]
+
+if not os.getenv('CASSANDRA_HOME') is None:
+    warnings.warn("'CASSANDRA_HOME' is set to be {}".format(os.getenv('CASSANDRA_HOME')))
 
 cmd = get_command(kind, cmd)
 if not cmd:

--- a/ccm
+++ b/ccm
@@ -96,7 +96,7 @@ else:
     cmd = sys.argv[2]
     cmd_args = [node] + sys.argv[3:]
 
-if not os.getenv('CASSANDRA_HOME') is None:
+if os.getenv('CASSANDRA_HOME') is not None:
     warnings.warn("'CASSANDRA_HOME' is set to be {}".format(os.getenv('CASSANDRA_HOME')))
 
 cmd = get_command(kind, cmd)

--- a/ccm
+++ b/ccm
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 
+import os
 import sys
+import warnings
+
 import pkg_resources
 from six import print_
 
 from ccmlib import common
-from ccmlib.cmds import command, cluster_cmds, node_cmds
-from ccmlib.remote import PARAMIKO_IS_AVAILABLE, get_remote_usage, get_remote_options, execute_ccm_remotely
-
-import os
-import warnings
+from ccmlib.cmds import cluster_cmds, command, node_cmds
+from ccmlib.remote import (PARAMIKO_IS_AVAILABLE, execute_ccm_remotely,
+                           get_remote_options, get_remote_usage)
 
 
 def get_command(kind, cmd):


### PR DESCRIPTION
Solution for Issue[340](https://github.com/riptano/ccm/issues/340).
If there is CASSANDRA_HOME environment variable, it will be warned.