### PR TITLE
Solution for #372 , Add "showlogs" command and CCM_MULTITAIL_CMD environment

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -705,7 +705,8 @@ class Cluster(object):
 
     def show_logs(self, selected_nodes_names=()):
         """
-        Shows logs of nodes in this cluster with multitail.
+        Shows logs of nodes in this cluster, by default, with multitail.
+        If you need to alter the command or options, change CCM_MULTITAIL_CMD .
         Params:
         @selected_nodes_names : a list-like object that contains names of nodes to be shown. If empty, this will show all nodes in the cluster.
 

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -702,3 +702,22 @@ class Cluster(object):
 
     def wait_for_any_log(self, pattern, timeout, filename='system.log', marks=None):
         return common.wait_for_any_log(self.nodelist(), pattern, timeout, filename=filename, marks=marks)
+
+    def show_logs(self, selected_nodes_names=()):
+        nodes = sorted(list(self.nodes.values()), key=lambda node: node.name)
+        nodes_names = [node.name for node in nodes]
+
+        if len(nodes) == 0:
+            print("No node in this cluster yet.")
+            return
+        else:
+            names_logs_dict = {node.name: node.logfilename() for node in nodes}
+            if len(selected_nodes_names) == 0:
+                return names_logs_dict.values()
+            else:
+                if set(selected_nodes_names).issubset(nodes_names):
+                    return [names_logs_dict[name] for name in selected_nodes_names]
+                else:
+                    raise ValueError("nodes in this cluster are {}. But nodes in argments are {}".format(
+                        nodes_names, selected_nodes_names
+                    ))

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -704,20 +704,28 @@ class Cluster(object):
         return common.wait_for_any_log(self.nodelist(), pattern, timeout, filename=filename, marks=marks)
 
     def show_logs(self, selected_nodes_names=()):
+        """
+        Shows logs of nodes in this cluster with multitail.
+        Params:
+        @selected_nodes_names : a list-like object that contains names of nodes to be shown. If empty, this will show all nodes in the cluster.
+
+        Triggers multitail to show logs. Detailed options for multitail are not configurable.
+        """
+
+        if len(self.nodes.values()) == 0:
+            print("The are no nodes in this cluster yet.")
+            return
+
         nodes = sorted(list(self.nodes.values()), key=lambda node: node.name)
         nodes_names = [node.name for node in nodes]
 
-        if len(nodes) == 0:
-            print("No node in this cluster yet.")
-            return
+        names_logs_dict = {node.name: node.logfilename() for node in nodes}
+        if len(selected_nodes_names) == 0: # Parameter selected_nodes_names is empty
+            return names_logs_dict.values()
         else:
-            names_logs_dict = {node.name: node.logfilename() for node in nodes}
-            if len(selected_nodes_names) == 0:
-                return names_logs_dict.values()
+            if set(selected_nodes_names).issubset(nodes_names):
+                return [names_logs_dict[name] for name in selected_nodes_names]
             else:
-                if set(selected_nodes_names).issubset(nodes_names):
-                    return [names_logs_dict[name] for name in selected_nodes_names]
-                else:
-                    raise ValueError("nodes in this cluster are {}. But nodes in argments are {}".format(
-                        nodes_names, selected_nodes_names
-                    ))
+                raise ValueError("nodes in this cluster are {}. But nodes in argments are {}".format(
+                    nodes_names, selected_nodes_names
+                ))

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -703,18 +703,19 @@ class Cluster(object):
     def wait_for_any_log(self, pattern, timeout, filename='system.log', marks=None):
         return common.wait_for_any_log(self.nodelist(), pattern, timeout, filename=filename, marks=marks)
 
-    def show_logs(self, selected_nodes_names=()):
+    def show_logs(self, selected_nodes_names=None):
         """
         Shows logs of nodes in this cluster, by default, with multitail.
         If you need to alter the command or options, change CCM_MULTITAIL_CMD .
         Params:
         @selected_nodes_names : a list-like object that contains names of nodes to be shown. If empty, this will show all nodes in the cluster.
-
-        Triggers multitail to show logs. Detailed options for multitail are not configurable.
         """
 
-        if len(self.nodes.values()) == 0:
-            print("The are no nodes in this cluster yet.")
+        if selected_nodes_names is None:
+            selected_nodes_names = []
+
+        if len(self.nodes) == 0:
+            print_("There are no nodes in this cluster yet.")
             return
 
         nodes = sorted(list(self.nodes.values()), key=lambda node: node.name)

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -347,15 +347,19 @@ class ClusterStatusCmd(Cmd):
 
 
 class ClusterShowlogsCmd(Cmd):
-    descr_text = "Show logs of nodes in this claster. If no nodes are specified, logs of all nodes will be shown."
+    descr_text = "Show logs of nodes in this claster. If no nodes are specified, logs of all nodes will be shown.\
+                 By default multitail is used. If you need to alter the command or options, change CCM_MULTITAIL_CMD."
+
     usage = "usage: ccm showlogs [node1 node2 ...]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, load_cluster=True)
 
     def run(self):
+        shower = os.getenv("CCM_MULTITAIL_CMD", 'multitail').split()[0]
+        shower_options = os.getenv("CCM_MULTITAIL_CMD", "").split()[1:]
         logs = self.cluster.show_logs(self.args)
-        os.execvp('multitail', ['multitail']+logs)
+        os.execvp(shower, [shower]+shower_options+logs)
 
 
 class ClusterRemoveCmd(Cmd):

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -347,8 +347,8 @@ class ClusterStatusCmd(Cmd):
 
 
 class ClusterShowlogsCmd(Cmd):
-    descr_text = "Show logs of nodes in this claster. If not determined, all nodes will be showed up"
-    usage = "usage: ccm showlogs [args (node1 node2 ...)]"
+    descr_text = "Show logs of nodes in this claster. If no nodes are specified, logs of all nodes will be shown."
+    usage = "usage: ccm showlogs [node1 node2 ...]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, load_cluster=True)

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -45,7 +45,8 @@ CLUSTER_CMDS = [
     "showlastlog",
     "jconsole",
     "setworkload",
-    "enableaoss"
+    "enableaoss",
+    "showlogs"
 ]
 
 
@@ -343,6 +344,18 @@ class ClusterStatusCmd(Cmd):
 
     def run(self):
         self.cluster.show(self.options.verbose)
+
+
+class ClusterShowlogsCmd(Cmd):
+    descr_text = "Show logs of nodes in this claster. If not determined, all nodes will be showed up"
+    usage = "usage: ccm showlogs [args (node1 node2 ...)]"
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, load_cluster=True)
+
+    def run(self):
+        logs = self.cluster.show_logs(self.args)
+        os.execvp('multitail', ['multitail']+logs)
 
 
 class ClusterRemoveCmd(Cmd):

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -347,7 +347,7 @@ class ClusterStatusCmd(Cmd):
 
 
 class ClusterShowlogsCmd(Cmd):
-    descr_text = "Show logs of nodes in this claster. If no nodes are specified, logs of all nodes will be shown.\
+    descr_text = "Show logs of nodes in this cluster. If no nodes are specified, logs of all nodes will be shown.\
                  By default multitail is used. If you need to alter the command or options, change CCM_MULTITAIL_CMD."
 
     usage = "usage: ccm showlogs [node1 node2 ...]"


### PR DESCRIPTION
#372 Requested adding ccm option that shows nodes' information in a parallel manner.
We implemented that feature "showlogs". By default it shows every node's log by "multitail" command.
By exporting command and options to CCM_MULTITAIL_CMD, you can execute any command and options to view the logs. If you want to specify nodes to be shown in a cluster, execute like
$ ccm showlogs [node1, node2, ...]