### PR TITLE
Improvements for re-enabling upgrade tests for CASSANDRA-14421

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -107,11 +107,15 @@ class Cluster(object):
             self.__version = v if v is not None else self.__get_version_from_build()
         self._update_config()
         for node in list(self.nodes.values()):
+            node._cassandra_version = self.__version
             node.import_config_files()
 
         # if any nodes have a data center, let's update the topology
         if any([node.data_center for node in self.nodes.values()]):
             self.__update_topology_files()
+
+        if self.cassandra_version() >= '4':
+            self.set_configuration_options({ 'start_rpc' : None}, delete_empty=True, delete_always=True)
 
         return self
 
@@ -573,9 +577,9 @@ class Cluster(object):
             pass
         return rc
 
-    def set_configuration_options(self, values=None):
+    def set_configuration_options(self, values=None, delete_empty=False, delete_always=False):
         if values is not None:
-            self._config_options = common.merge_configuration(self._config_options, values)
+            self._config_options = common.merge_configuration(self._config_options, values, delete_empty=delete_empty, delete_always=delete_always)
 
         self._persist_config()
         self.__update_topology_files()

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -725,7 +725,7 @@ def assert_jdk_valid_for_cassandra_version(cassandra_version):
         exit(1)
 
 
-def merge_configuration(original, changes, delete_empty=True):
+def merge_configuration(original, changes, delete_empty=True, delete_always=False):
     if not isinstance(original, dict):
         # if original is not a dictionary, assume changes override it.
         new = changes
@@ -738,7 +738,7 @@ def merge_configuration(original, changes, delete_empty=True):
             if delete_empty and k in new and new[k] is not None and \
                     (v is None or (isinstance(v, str) and len(v) == 0)):
                 del new[k]
-            else:
+            elif not delete_always:
                 new_value = v
                 # If key is in both dicts, update it with new values.
                 if k in new:

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -289,6 +289,10 @@ class Node(object):
         self.import_config_files()
         self.import_bin_files()
         self.__conf_updated = False
+
+        if self.get_cassandra_version() >= '4':
+            self.set_configuration_options(values={'start_rpc': None}, delete_empty=True, delete_always=True)
+
         return self
 
     def set_workloads(self, workloads):
@@ -301,7 +305,7 @@ class Node(object):
         version = self.get_cassandra_version()
         return float('.'.join(version.vstring.split('.')[:2]))
 
-    def set_configuration_options(self, values=None):
+    def set_configuration_options(self, values=None, delete_empty=False, delete_always=False):
         """
         Set Cassandra configuration options.
         ex:
@@ -310,11 +314,11 @@ class Node(object):
                 'concurrent_writes' : 64,
             })
         """
-        if not hasattr(self,'_config_options') or self.__config_options is None:
+        if (not hasattr(self,'__config_options') and not hasattr(self,'_Node__config_options')) or self.__config_options is None:
             self.__config_options = {}
 
         if values is not None:
-            self.__config_options = common.merge_configuration(self.__config_options, values)
+            self.__config_options = common.merge_configuration(self.__config_options, values, delete_empty=delete_empty, delete_always=delete_always)
 
         self.import_config_files()
 

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -394,11 +394,12 @@ def compile_version(version, target_dir, verbose=False):
             if attempt > 0:
                 logger.info("\n\n`ant jar` failed. Retry #%s...\n\n" % attempt)
             process = subprocess.Popen([platform_binary('ant'), 'jar'], cwd=target_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            ret_val, _, _ = log_info(process, logger)
+            ret_val, stdout, stderr = log_info(process, logger)
             attempt += 1
         if ret_val is not 0:
             raise CCMError('Error compiling Cassandra. See {logfile} or run '
-                           '"ccm showlastlog" for details'.format(logfile=logfile))
+                           '"ccm showlastlog" for details, stdout=\'{stdout}\' stderr=\'{stderr}\''.format(
+                logfile=logfile, stdout=stdout.decode(), stderr=stderr.decode()))
     except OSError as e:
         raise CCMError("Error compiling Cassandra. Is ant installed? See %s for details" % logfile)
 


### PR DESCRIPTION
Improve removal of configuration options by making it possible to specify a list of options to remove.

Automatically remove unsupported config options on version change.

Include stdout/stderr in exception message for failed compile since this is all CircleCI shows.