### PR TITLE
More fixes for CASSANDRA-14421 to make changing versions easier

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import time
 from collections import OrderedDict, defaultdict, namedtuple
+from distutils.version import LooseVersion #pylint: disable=import-error, no-name-in-module
 
 import yaml
 from six import iteritems, print_
@@ -105,6 +106,8 @@ class Cluster(object):
             dir, v = repository.setup(version, verbose)
             self.__install_dir = dir
             self.__version = v if v is not None else self.__get_version_from_build()
+            if not isinstance(self.__version, LooseVersion):
+                self.__version = LooseVersion(self.__version)
         self._update_config()
         for node in list(self.nodes.values()):
             node._cassandra_version = self.__version
@@ -116,6 +119,8 @@ class Cluster(object):
 
         if self.cassandra_version() >= '4':
             self.set_configuration_options({ 'start_rpc' : None}, delete_empty=True, delete_always=True)
+        else:
+            self.set_configuration_options(common.CCM_40_YAML_OPTIONS, delete_empty=True, delete_always=True)
 
         return self
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -40,6 +40,18 @@ CASSANDRA_SH = "cassandra.in.sh"
 CONFIG_FILE = "config"
 CCM_CONFIG_DIR = "CCM_CONFIG_DIR"
 
+def get_options_removal_dict(options):
+    dict = {}
+    for option in options:
+        dict[option] = None
+    return dict
+
+#Options introduced in 4.0
+CCM_40_YAML_OPTIONS = get_options_removal_dict(['repaired_data_tracking_for_range_reads_enabled',
+                  'corrupted_tombstone_strategy',
+                  'repaired_data_tracking_for_partition_reads_enabled',
+                  'report_unconfirmed_repaired_data_mismatches'])
+
 class InfoFilter(logging.Filter):
     def filter(self, rec):
         return rec.levelno in (logging.DEBUG, logging.INFO)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -293,7 +293,8 @@ class Node(object):
         if self.get_cassandra_version() >= '4':
             self.set_configuration_options(values={'start_rpc': None}, delete_empty=True, delete_always=True)
             self.set_configuration_options(values={'rpc_port': None}, delete_empty=True, delete_always=True)
-
+        else:
+            self.set_configuration_options(common.CCM_40_YAML_OPTIONS, delete_empty=True, delete_always=True)
 
         return self
 

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -560,6 +560,6 @@ def get_logger(log_file):
 def log_info(process, logger):
     stdoutdata, stderrdata = process.communicate()
     rc = process.returncode
-    logger.info(stdoutdata)
-    logger.info(stderrdata)
+    logger.info(stdoutdata.decode())
+    logger.info(stderrdata.decode())
     return rc, stdoutdata, stderrdata


### PR DESCRIPTION
When setting a new version use LooseVersion for the version field in Cluster to be consistent. Some test code fails because it expects a LooseVersion all the time.

When going from > 4.0 version to a < 4.0 version remove the 4.0 options automatically.