### PR TITLE
handle zombie processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.5.4"
   - "3.6.3"
 install:
-  - pip install pylint six pyyaml paramiko
+  - pip install pylint six pyyaml paramiko psutil
 script:
   - pylint --py3k --disable=W1633,W1648 ccmlib
   - pylint --disable=all --enable=E,F ccmlib

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds'],
     scripts=[ccmscript],
-    install_requires=['pyYaml', 'six >=1.4.1'],
+    install_requires=['pyYaml', 'six >=1.4.1', 'psutil'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
Recently something seems to have changed in circleci, making it leave defunct/zombie processes with symptoms like this: https://circleci.com/gh/krummas/cassandra/1478#tests/containers/25

And ccm currently doesn't handle this scenario - it keeps trying to kill the process but it wont die, this PR adds a check if the process is zombie and then just ignores it. 