### PR TITLE
allowing dash in Cassandra version number, i.e. 4.0.alpha2

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -281,7 +281,7 @@ class Node(object):
 
     def get_base_cassandra_version(self):
         version = self.get_cassandra_version()
-        return float('.'.join(version.vstring.split('.')[:2]))
+        return float('.'.join(re.split('\.|-',version.vstring)[:2]))
 
     def set_configuration_options(self, values=None):
         """

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -340,9 +340,9 @@ def download_version(version, url=None, verbose=False, binary=False):
         archive_url = CCM_CONFIG.get('repositories', 'cassandra')
 
     if binary:
-        archive_url = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (archive_url, version.split('-')[0], version) if url is None else url
+        archive_url = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (archive_url, version, version) if url is None else url
     else:
-        archive_url = "%s/%s/apache-cassandra-%s-src.tar.gz" % (archive_url, version.split('-')[0], version) if url is None else url
+        archive_url = "%s/%s/apache-cassandra-%s-src.tar.gz" % (archive_url, version, version) if url is None else url
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
         __download(archive_url, target, show_progress=verbose)


### PR DESCRIPTION
fixes #702 