### PR TITLE
Run travis with JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ script:
   - pylint --py3k --disable=W1633,W1648 ccmlib
   - pylint --disable=all --enable=E,F ccmlib
   - nosetests
+
+jdk:
+  - openjdk8


### PR DESCRIPTION
Currently travis runs with JDK11 and tests that bring up nodes don't
work because of
```
[node1 ERROR] b"intx ThreadPriorityPolicy=42 is outside the allowed range [ 0 ... 1 ]\nImproperly specified VM option 'ThreadPriorityPolicy=42'\nError: Could not create the Java Virtual Machine.\nError: A fatal exception has occurred. Program will exit."
```

Running travis with JDK8 should fix that issue.