### PR TITLE
Fix Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
+dist: xenial
 language: python
 python:
   - "2.7.13"
-  - "3.4.5"
-  - "3.5.4"
-  - "3.6.3"
+  - "3.6.10"
+  - "3.7.7"
+  - "3.8.2"
 install:
   - pip install pylint six pyyaml paramiko psutil
 script:
   - pylint --py3k --disable=W1633,W1648 ccmlib
   - pylint --disable=all --enable=E,F ccmlib
   - nosetests
+jdk:
+  - openjdk11
+env:
+  - CASSANDRA_USE_JDK11=true
+addons:
+  apt:
+    packages:
+      - ant
+      - ant-optional

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -4,19 +4,16 @@ from six import StringIO
 
 import ccmlib
 from ccmlib.cluster import Cluster
-
 from . import TEST_DIR, ccmtest
 
 sys.path = [".."] + sys.path
-
-
 
 CLUSTER_PATH = TEST_DIR
 
 
 class TestCCMLib(ccmtest.Tester):
     def test2(self):
-        self.cluster = Cluster(CLUSTER_PATH, "test2", cassandra_version='2.0.3')
+        self.cluster = Cluster(CLUSTER_PATH, "test2", cassandra_version='git:trunk')
         self.cluster.populate(2)
         self.cluster.start()
 
@@ -37,7 +34,7 @@ class TestCCMLib(ccmtest.Tester):
         self.cluster.stop()
 
     def test3(self):
-        self.cluster = Cluster(CLUSTER_PATH, "test3", cassandra_version='2.0.3')
+        self.cluster = Cluster(CLUSTER_PATH, "test3", cassandra_version='git:trunk')
         self.cluster.populate(2)
         self.cluster.start()
         self.cluster.cleanup()


### PR DESCRIPTION
Currently travis runs with JDK11 and tests that bring up nodes don't
work because of
```
[node1 ERROR] b"intx ThreadPriorityPolicy=42 is outside the allowed range [ 0 ... 1 ]\nImproperly specified VM option 'ThreadPriorityPolicy=42'\nError: Could not create the Java Virtual Machine.\nError: A fatal exception has occurred. Program will exit."
```
Another issue is that the build doesn't work with Python 3.4.

It makes sense here to test with latest C* 4.0 and with Python 3.8.

Successful run here: https://travis-ci.org/github/riptano/ccm/builds/676080025