### PR TITLE
ccmlib should not always terminate cql statements with a ';'

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -902,7 +902,7 @@ class Node(object):
         p = self.verify_process(options=options)
         return handle_external_tool_process(p, ['sstableverify'] + options)
 
-    def run_cqlsh_process(self, cmds=None, cqlsh_options=None):
+    def run_cqlsh_process(self, cmds=None, cqlsh_options=None, terminator=''):
         if cqlsh_options is None:
             cqlsh_options = []
         cqlsh = self.get_tool('cqlsh')
@@ -931,13 +931,13 @@ class Node(object):
             for cmd in cmds.split(';'):
                 cmd = cmd.strip()
                 if cmd:
-                    p.stdin.write(cmd + ';\n')
+                    p.stdin.write(cmd + terminator)
             p.stdin.write("quit;\n")
 
         return p
 
-    def run_cqlsh(self, cmds=None, cqlsh_options=None):
-        p = self.run_cqlsh_process(cmds, cqlsh_options)
+    def run_cqlsh(self, cmds=None, cqlsh_options=None, terminator=';\n'):
+        p = self.run_cqlsh_process(cmds, cqlsh_options, terminator)
         return handle_external_tool_process(p, ['cqlsh', cmds, cqlsh_options])
 
     def set_log_level(self, new_level, class_name=None):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if system() == "Windows":
 
 setup(
     name='ccm',
-    version='3.1.3',
+    version='3.1.4',
     description='Cassandra Cluster Manager',
     long_description=open(abspath(join(dirname(__file__), 'README.md'))).read(),
     author='Sylvain Lebresne',


### PR DESCRIPTION
I am running into an issue that ccmlib assumes [all input will be terminated by a `;`](https://github.com/riptano/ccm/blob/275699f79d102b5039b79cc17fa6305dccf18412/ccmlib/node.py#L910). This isn't true in case of lets say comments or multi-line comments. ccmlib should optionally take a terminator to avoid this issue.

Here's an example of a failure:

```python
self.node1.run_cqlsh(
   """/* multiline
    *
    * comment */
    """)
```

Attached patch fixes the issue. @snazy @nastra could you please review this PR?
