### PR TITLE
CASSANDRA-15835: Use the right Java version + JAVA_HOME when building C* from source / cassandra-test

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -431,13 +431,11 @@ class Cluster(object):
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=True,
               wait_other_notice=True, jvm_args=None, profile_options=None,
-              quiet_start=False, allow_root=False, **kwargs):
+              quiet_start=False, allow_root=False, jvm_version=None, **kwargs):
         if jvm_args is None:
             jvm_args = []
 
         extension.pre_cluster_start(self)
-
-        common.assert_jdk_valid_for_cassandra_version(self.cassandra_version())
 
         # check whether all loopback aliases are available before starting any nodes
         for node in list(self.nodes.values()):
@@ -453,7 +451,9 @@ class Cluster(object):
                 if os.path.exists(node.logfilename()):
                     mark = node.mark_log()
 
-                p = node.start(update_pid=False, jvm_args=jvm_args, profile_options=profile_options, verbose=verbose, quiet_start=quiet_start, allow_root=allow_root)
+                p = node.start(update_pid=False, jvm_args=jvm_args, jvm_version=jvm_version,
+                               profile_options=profile_options, verbose=verbose, quiet_start=quiet_start,
+                               allow_root=allow_root)
 
                 # Prior to JDK8, starting every node at once could lead to a
                 # nanotime collision where the RNG that generates a node's tokens

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -711,14 +711,25 @@ def invalidate_cache():
     rmdirs(os.path.join(get_default_path(), 'repository'))
 
 
-def get_jdk_version():
+def get_jdk_version_int(process='java'):
+    jdk_version = float(get_jdk_version(process))
+    # Make it Java 8 instead of 1.8 (or 7 instead of 1.7)
+    jdk_version = int(jdk_version if jdk_version >= 2 else 10*(jdk_version-1))
+    return jdk_version
+
+
+def get_jdk_version(process='java'):
     """
     Retrieve the Java version as reported in the quoted string returned
     by invoking 'java -version'.
-
-    Works for Java 1.8, Java 9 and should also be fine for Java 10.
+    Works for Java 1.8, Java 9 and newer.
     """
-    version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
+    try:
+        version = subprocess.check_output([process, '-version'], stderr=subprocess.STDOUT)
+    except OSError:
+        print_("ERROR: Could not find java. Is it in your path?")
+        exit(1)
+
     return _get_jdk_version(version)
 
 
@@ -731,9 +742,119 @@ def _get_jdk_version(version):
     return re.search(ver_pattern, str(version)).groups()[0] + ".0"
 
 
+def update_java_version(jvm_version=None, install_dir=None, cassandra_version=None, env=None,
+                        for_build=False, info_message=None):
+    """
+    Updates or fixes the Java version (JAVA_HOME environment).
+    If 'jvm_version' is explicitly set, that one will be used.
+    Otherwise, the Java version will be guessed from the provided 'cassandra_version' parameter.
+    If the version-parameters are not specified, those will be inquired from the 'install_dir'.
+    See CASSANDRA-15835
+    :param jvm_version: The Java version to use - must be the major Java version number like 8 or 11.
+    :param install_dir: Software installation directory.
+    :param cassandra_version: The Cassandra version to consider for choosing the correct Java version.
+    :param env: Current OS environment variables.
+    :param for_build: whether the code should check for a valid version to build or run bdp. Currently only
+    applies to source tree that have a 'build-env.yaml' file.
+    :param info_message: String logged with info/error messages
+    :return: the maybe updated OS environment variables. If 'env' was 'None' and JAVA_HOME needs to be set,
+    the result will also contain the current OS environment variables from 'os.environ'.
+    """
+
+    env = env if env else os.environ
+
+    current_java_version = get_jdk_version_int()
+    current_java_home_version = get_jdk_version_int('{}/bin/java'.format(env['JAVA_HOME'])) if 'JAVA_HOME' in env else current_java_version
+    # Code to ensure that we start C* using the correct Java version.
+    # This is important especially after CASSANDRA-9608 (Java 11 support) when dtests are run using Java 11
+    # but a "manually" configured (set_install_dir()) different version requires Java 8.
+    return _update_java_version(current_java_version, current_java_home_version,
+                                jvm_version=jvm_version, install_dir=install_dir,
+                                cassandra_version=cassandra_version, env=env,
+                                for_build=for_build, info_message=info_message)
+
+
+def _update_java_version(current_java_version, current_java_home_version,
+                         jvm_version=None, install_dir=None, cassandra_version=None, env=None,
+                         for_build=False, info_message=None, os_env=None):
+    # Internal variant accessible for tests
+
+    if env is None:
+        raise RuntimeError("env passed to _update_java_version must not be None")
+
+    if cassandra_version is None and install_dir:
+        cassandra_version = get_version_from_build(install_dir)
+
+    # conservative Java version defaults
+    # Cassandra versions 3.x and 2.x use the defaults
+    build_versions = [8]
+    run_versions = [8]
+
+    info('{}: current_java_version={}, current_java_home_version={}, jvm_version={}, for_build={}, cassandra_version={}, install_dir={}, env={}'
+         .format(info_message, current_java_version, current_java_home_version, jvm_version, for_build, cassandra_version, install_dir, env))
+
+    if cassandra_version >= '4.0':
+        if not os_env:
+            os_env = os.environ
+        if 'CASSANDRA_USE_JDK11' not in os_env:
+            build_versions = [8, 11]
+            run_versions = [8, 11, 12, 13, 14, 15, 16, 17]
+        else:
+            build_versions = [11]
+            run_versions = [11]
+
+    versions = build_versions if for_build else run_versions
+
+    if not jvm_version:
+        if current_java_version in versions:
+            jvm_version = current_java_version
+        else:
+            for version in versions:
+                if 'JAVA{}_HOME'.format(version) in env:
+                    jvm_version = version
+                    break
+
+        if jvm_version:
+            info('{}: using Java {} for the current invocation'
+                 .format(info_message, jvm_version))
+    else:
+        # Called proved an explicit Java version
+        info('{}: Using explicitly requested Java version {} for the current invocation of Cassandra {}'
+             .format(info_message, jvm_version, cassandra_version))
+
+    # If the 'java' binary accessible via PATH points to a different Java version than the current JAVA_HOME,
+    # update it to point to the Java version of the 'java' binary accessible via PATH.
+    # Need to do this, because ccmlib.common.compile_version() uses the 'java' binary accessible via PATH via 'ant'.
+    if not jvm_version:
+        if current_java_home_version != current_java_version:
+            jvm_version = current_java_version
+            info('{}: Using Java {} for Cassandra {}, because the Java versions of java binary in PATH ({}) and '
+                 'JAVA_HOME ({}) did not match'.format(info_message, current_java_version, cassandra_version,
+                                                       current_java_version, current_java_home_version))
+        else:
+            jvm_version = current_java_version
+
+    if current_java_version != jvm_version or current_java_home_version != jvm_version:
+        new_java_home = 'JAVA{}_HOME'.format(jvm_version)
+        if new_java_home not in env:
+            raise RuntimeError("{}: You need to set JAVA{}_HOME to run Cassandra {}"
+                               .format(info_message, jvm_version, cassandra_version))
+        env['JAVA_HOME'] = env[new_java_home]
+        env['PATH'] = '{}/bin:{}'.format(env[new_java_home], env['PATH'] if 'PATH' in env else '')
+    return env
+
+
 def assert_jdk_valid_for_cassandra_version(cassandra_version):
-    if cassandra_version >= '3.0' and get_jdk_version() < '1.8':
-        print_('ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(get_jdk_version()))
+    jdk_version = float(get_jdk_version())
+    if cassandra_version >= '4.0':
+        if jdk_version < 1.8 or 9 <= jdk_version < 11:
+            error('Cassandra {} requires Java 1.8 or Java 11, found Java {}'.format(cassandra_version, jdk_version))
+            exit(1)
+    elif cassandra_version >= '3.0' and jdk_version != 1.8:
+        error('Cassandra {} requires Java 1.8, found Java {}'.format(cassandra_version, jdk_version))
+        exit(1)
+    elif cassandra_version < '3.0' and (jdk_version < 1.7 or jdk_version > 1.8):
+        error('Cassandra {} requires Java 1.7 or 1.8, found Java {}'.format(cassandra_version, jdk_version))
         exit(1)
 
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -14,7 +14,6 @@ import stat
 import subprocess
 import sys
 import time
-import tempfile
 import warnings
 from collections import namedtuple
 from datetime import datetime
@@ -117,6 +116,7 @@ class Node(object):
         self.__global_log_level = None
         self.__classes_log_level = {}
         self.__environment_variables = environment_variables or {}
+        self.__original_java_home = None
         self.__conf_updated = False
 
         if derived_cassandra_version:
@@ -203,6 +203,11 @@ class Node(object):
         if update_conf:
             self.__conf_updated = True
         env = common.make_cassandra_env(self.get_install_dir(), self.get_path(), update_conf)
+        env = common.update_java_version(jvm_version=None,
+                                         install_dir=self.get_install_dir(),
+                                         cassandra_version=self.cluster.cassandra_version(),
+                                         env=env,
+                                         info_message=self.name)
         for (key, value) in self.__environment_variables.items():
             env[key] = value
         return env
@@ -389,20 +394,23 @@ class Node(object):
         self.__update_status()
         return self.status == Status.UP
 
+    def log_directory(self):
+        return os.path.join(self.get_path(), 'logs')
+
     def logfilename(self):
         """
         Return the path to the current Cassandra log of this node.
         """
-        return os.path.join(self.get_path(), 'logs', 'system.log')
+        return os.path.join(self.log_directory(), 'system.log')
 
     def debuglogfilename(self):
-        return os.path.join(self.get_path(), 'logs', 'debug.log')
+        return os.path.join(self.log_directory(), 'debug.log')
 
     def gclogfilename(self):
-        return os.path.join(self.get_path(), 'logs', 'gc.log.0.current')
+        return os.path.join(self.log_directory(), 'gc.log.0.current')
 
     def compactionlogfilename(self):
-        return os.path.join(self.get_path(), 'logs', 'compaction.log')
+        return os.path.join(self.log_directory(), 'compaction.log')
 
     def envfilename(self):
         return os.path.join(
@@ -417,7 +425,7 @@ class Node(object):
         """
         matchings = []
         pattern = re.compile(expr)
-        with open(os.path.join(self.get_path(), 'logs', filename)) as f:
+        with open(os.path.join(self.log_directory(), filename)) as f:
             if from_mark:
                 f.seek(from_mark)
             for line in f:
@@ -434,7 +442,7 @@ class Node(object):
         return self.grep_log_for_errors_from(seek_start=getattr(self, 'error_mark', 0))
 
     def grep_log_for_errors_from(self, filename='system.log', seek_start=0):
-        with open(os.path.join(self.get_path(), 'logs', filename)) as f:
+        with open(os.path.join(self.log_directory(), filename)) as f:
             f.seek(seek_start)
             return _grep_log_for_errors(f.read())
 
@@ -451,7 +459,7 @@ class Node(object):
         This is for use with the from_mark parameter of watch_log_for_* methods,
         allowing to watch the log from the position when this method was called.
         """
-        log_file = os.path.join(self.get_path(), 'logs', filename)
+        log_file = os.path.join(self.log_directory(), filename)
         if not os.path.exists(log_file):
             return 0
         with open(log_file) as f:
@@ -489,7 +497,7 @@ class Node(object):
         if len(tofind) == 0:
             return None
 
-        log_file = os.path.join(self.get_path(), 'logs', filename)
+        log_file = os.path.join(self.log_directory(), filename)
         output_read = False
         while not os.path.exists(log_file):
             time.sleep(.5)
@@ -622,7 +630,8 @@ class Node(object):
               use_jna=False,
               quiet_start=False,
               allow_root=False,
-              set_migration_task=True):
+              set_migration_task=True,
+              jvm_version=None):
         """
         Start the node. Options includes:
           - join_ring: if false, start the node with -Dcassandra.join_ring=False
@@ -703,15 +712,41 @@ class Node(object):
             args.append('-R')
         env['JVM_EXTRA_OPTS'] = env.get('JVM_EXTRA_OPTS', "") + " " + " ".join(jvm_args)
 
+        # Upgrade scenarios may want to test upgrades to a specific Java version. In case a prior C* version
+        # requires a lower Java version, we would keep its JAVA_HOME in self.__environment_variables and therefore
+        # prevent using the "intended" Java version for the C* version to upgrade to.
+        if not self.__original_java_home:
+            # Save the "original" JAVA_HOME + PATH to restore it.
+            self.__original_java_home = os.environ['JAVA_HOME']
+        else:
+            # Restore the "original" JAVA_HOME + PATH to restore it.
+            env['JAVA_HOME'] = self.__original_java_home
+        env = common.update_java_version(jvm_version=jvm_version,
+                                         install_dir=self.get_install_dir(),
+                                         cassandra_version=self.get_cassandra_version(),
+                                         env=env,
+                                         info_message=self.name)
+        # Need to update the node's environment for nodetool and other tools.
+        # (e.g. the host's JAVA_HOME points to Java 11, but the node's software is only for Java 8)
+        self.__environment_variables = {
+            'JAVA_HOME': env['JAVA_HOME'],
+            'PATH': env['PATH']
+        }
+
+        common.info("Starting {} with JAVA_HOME={} java_version={} cassandra_version={}, install_dir={}"
+                    .format(self.name, env['JAVA_HOME'], common.get_jdk_version_int(),
+                            self.get_cassandra_version(), self.get_install_dir()))
+
         # In case we are restarting a node
         # we risk reading the old cassandra.pid file
         self._delete_old_pid()
 
         process = None
-        FNULL = open(os.devnull, 'w')
-        stdout_sink = subprocess.PIPE if verbose else FNULL
+        start_time = time.time()
+        # Always write the stdout+stderr of the launched process to log files to make finding startup issues easier.
+        stdout_sink = open(os.path.join(self.log_directory(), 'startup-{}-stdout.log'.format(start_time)), "w+")
         # write stderr to a temporary file to prevent overwhelming pipe (> 65K data).
-        stderr = tempfile.SpooledTemporaryFile(max_size=0xFFFF)
+        stderr_sink = open(os.path.join(self.log_directory(), 'startup-{}-stderr.log'.format(start_time)), "w+")
 
         if common.is_win():
             # clean up any old dirty_pid files from prior runs
@@ -721,19 +756,19 @@ class Node(object):
             if quiet_start and self.cluster.version() >= '2.2.4':
                 args.append('-q')
 
-            process = subprocess.Popen(args, cwd=self.get_bin_dir(), env=env, stdout=stdout_sink, stderr=stderr)
+            process = subprocess.Popen(args, cwd=self.get_bin_dir(), env=env, stdout=stdout_sink, stderr=stderr_sink)
         else:
-            process = subprocess.Popen(args, env=env, stdout=stdout_sink, stderr=stderr)
+            process = subprocess.Popen(args, env=env, stdout=stdout_sink, stderr=stderr_sink)
 
-        process.stderr_file = stderr
+        process.stderr_file = stderr_sink
+
+        if verbose:
+            stdout, stderr = process.communicate()
+            print_(str(stdout))
+            print_(str(stderr))
 
         # Our modified batch file writes a dirty output with more than just the pid - clean it to get in parity
         # with *nix operation here.
-        if verbose:
-            stdout, stderr = process.communicate()
-            print_(stdout)
-            print_(stderr)
-
         if common.is_win():
             self.__clean_win_pid()
             self._update_pid(process)
@@ -1590,7 +1625,7 @@ class Node(object):
     def _update_log4j(self):
         append_pattern = 'log4j.appender.R.File='
         conf_file = os.path.join(self.get_conf_dir(), common.LOG4J_CONF)
-        log_file = os.path.join(self.get_path(), 'logs', 'system.log')
+        log_file = os.path.join(self.log_directory(), 'system.log')
         # log4j isn't partial to Windows \.  I can't imagine why not.
         if common.is_win():
             log_file = re.sub("\\\\", "/", log_file)
@@ -1711,7 +1746,7 @@ class Node(object):
         # gc.log was turned on by default in 2.2.5/3.0.3/3.3
         if self.get_cassandra_version() >= '2.2.5':
             gc_log_pattern = "-Xloggc"
-            gc_log_path = os.path.join(self.get_path(), 'logs', 'gc.log')
+            gc_log_path = os.path.join(self.log_directory(), 'gc.log')
             if common.is_win():
                 gc_log_setting = '    $env:JVM_OPTS="$env:JVM_OPTS -Xloggc:{}"'.format(gc_log_path)
             else:

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -4,11 +4,234 @@ from six import StringIO
 
 import ccmlib
 from ccmlib.cluster import Cluster
+from ccmlib.common import _update_java_version
 from . import TEST_DIR, ccmtest
+from distutils.version import LooseVersion  # pylint: disable=import-error, no-name-in-module
 
 sys.path = [".."] + sys.path
 
 CLUSTER_PATH = TEST_DIR
+
+
+class TestUpdateJavaVersion(ccmtest.Tester):
+    def test_update_java_version(self):
+        # Tests for C*-4.0 (Java 8 or 11 or newer)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_1',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_2',
+                                          os_env={'X': '1'})
+        self.assertEqual({'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_3',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_4',
+                                          os_env={'X': '1'})
+        self.assertEqual({'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_5',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_6',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_7',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_8',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_9',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=8,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_10',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=11,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_11',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'PATH': '/some/bin:/opt/foo/java_home11/bin',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11'},
+                                          for_build=False, info_message='test_update_java_version_4.0_12',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin:/opt/foo/java_home11/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        # Tests for pre-C*-4.0 (Java 8 only)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_1',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_2',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_3',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'PATH': '/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_4',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_5',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
 
 
 class TestCCMLib(ccmtest.Tester):
@@ -28,7 +251,7 @@ class TestCCMLib(ccmtest.Tester):
         self.cluster.show(True)
         self.cluster.show(False)
 
-        #self.cluster.stress([])
+        # self.cluster.stress([])
         self.cluster.compact()
         self.cluster.drain()
         self.cluster.stop()
@@ -84,6 +307,7 @@ class TestRunCqlsh(ccmtest.Tester):
 
         if return_output and show_output:
             self.assertEqual(printed_output, rv[0])
+
 
 class TestNodeLoad(ccmtest.Tester):
 


### PR DESCRIPTION
Also:
* Add a new "version source type" `clone:/path/to/local/cassandra/clone` to re-enable upgrade-dtests for dev-CI and local upgrade-dtest runs after CASSANDRA-14420 + CASSANDRA-14421
* Introduce new node startup logfiles for stdout+stderr
* Use `./gradlew` instead of `ant` to build C*, if `gradlew` is present