### PR TITLE
CASSANDRA-15835: Use the right Java version + JAVA_HOME when building C* from source / master

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -374,13 +374,11 @@ class Cluster(object):
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=True,
               wait_other_notice=True, jvm_args=None, profile_options=None,
-              quiet_start=False, allow_root=False, **kwargs):
+              quiet_start=False, allow_root=False, jvm_version=None, **kwargs):
         if jvm_args is None:
             jvm_args = []
 
         extension.pre_cluster_start(self)
-
-        common.assert_jdk_valid_for_cassandra_version(self.cassandra_version())
 
         # check whether all loopback aliases are available before starting any nodes
         for node in list(self.nodes.values()):
@@ -396,7 +394,9 @@ class Cluster(object):
                 if os.path.exists(node.logfilename()):
                     mark = node.mark_log()
 
-                p = node.start(update_pid=False, jvm_args=jvm_args, profile_options=profile_options, verbose=verbose, quiet_start=quiet_start, allow_root=allow_root)
+                p = node.start(update_pid=False, jvm_args=jvm_args, jvm_version=jvm_version,
+                               profile_options=profile_options, verbose=verbose, quiet_start=quiet_start,
+                               allow_root=allow_root)
 
                 # Prior to JDK8, starting every node at once could lead to a
                 # nanotime collision where the RNG that generates a node's tokens

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -24,8 +24,7 @@ except ImportError:
 
 from ccmlib import common
 from ccmlib.common import (ArgumentError, CCMError,
-                           assert_jdk_valid_for_cassandra_version,
-                           get_default_path, get_version_from_build,
+                           update_java_version, get_default_path, get_jdk_version_int,
                            platform_binary, rmdirs, validate_install_dir)
 from six.moves import urllib
 
@@ -75,8 +74,11 @@ def setup(version, verbose=False):
 
     elif version.startswith('source:'):
         version = version.replace('source:', '')
-        binary = False
-        fallback = False
+
+    elif version.startswith('clone:'):
+        # locally present C* source tree
+        version = version.replace('clone:', '')
+        return (version, None)
 
     elif version.startswith('alias:'):
         alias = version.split(":")[1].split("/")[0]
@@ -333,7 +335,6 @@ def download_version(version, url=None, verbose=False, binary=False):
 
     if binary == True, download precompiled tarball, otherwise build from source tarball.
     """
-    assert_jdk_valid_for_cassandra_version(version)
 
     archive_url = ARCHIVE
     if CCM_CONFIG.has_option('repositories', 'cassandra'):
@@ -382,14 +383,14 @@ def download_version(version, url=None, verbose=False, binary=False):
 
 
 def compile_version(version, target_dir, verbose=False):
-    assert_jdk_valid_for_cassandra_version(get_version_from_build(target_dir))
-
     # compiling cassandra and the stress tool
     logfile = lastlogfilename()
     logger = get_logger(logfile)
 
     common.info("Compiling Cassandra {} ...".format(version))
     logger.info("--- Cassandra Build -------------------\n")
+
+    env = update_java_version(install_dir=target_dir, for_build=True, info_message='Cassandra {} build'.format(version))
 
     default_build_properties = os.path.join(common.get_default_path(), 'build.properties.default')
     if os.path.exists(default_build_properties):
@@ -402,11 +403,20 @@ def compile_version(version, target_dir, verbose=False):
         # Similar patch seen with buildbot
         attempt = 0
         ret_val = 1
-        while attempt < 3 and ret_val is not 0:
+        gradlew = os.path.join(target_dir, platform_binary('gradlew'))
+        if os.path.exists(gradlew):
+            cmd = [gradlew, 'jar']
+        else:
+            # No gradle, use ant
+            cmd = [platform_binary('ant'), 'jar']
+            if get_jdk_version_int() >= 11:
+                cmd.append('-Duse.jdk11=true')
+        while attempt < 3 and ret_val != 0:
             if attempt > 0:
-                logger.info("\n\n`ant jar` failed. Retry #%s...\n\n" % attempt)
-            process = subprocess.Popen([platform_binary('ant'), 'jar'], cwd=target_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            ret_val, _, _ = log_info(process, logger)
+                logger.info("\n\n`{}` failed. Retry #{}...\n\n".format(' '.join(cmd), attempt))
+            process = subprocess.Popen(cmd, cwd=target_dir, env=env,
+                                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            ret_val, stdout, stderr = log_info(process, logger)
             attempt += 1
         if ret_val is not 0:
             raise CCMError('Error compiling Cassandra. See {logfile} or run '
@@ -414,13 +424,13 @@ def compile_version(version, target_dir, verbose=False):
     except OSError as e:
         raise CCMError("Error compiling Cassandra. Is ant installed? See %s for details" % logfile)
 
-    logger.info("\n\n--- cassandra/stress build ------------\n")
     stress_dir = os.path.join(target_dir, "tools", "stress") if (
         version >= "0.8.0") else \
         os.path.join(target_dir, "contrib", "stress")
 
     build_xml = os.path.join(stress_dir, 'build.xml')
     if os.path.exists(build_xml):  # building stress separately is only necessary pre-1.1
+        logger.info("\n\n--- cassandra/stress build ------------\n")
         try:
             # set permissions correctly, seems to not always be the case
             stress_bin_dir = os.path.join(stress_dir, 'bin')
@@ -428,10 +438,12 @@ def compile_version(version, target_dir, verbose=False):
                 full_path = os.path.join(stress_bin_dir, f)
                 os.chmod(full_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
-            process = subprocess.Popen([platform_binary('ant'), 'build'], cwd=stress_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            process = subprocess.Popen([platform_binary('ant'), 'build'], cwd=stress_dir, env=env,
+                                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             ret_val, _, _ = log_info(process, logger)
-            if ret_val is not 0:
-                process = subprocess.Popen([platform_binary('ant'), 'stress-build'], cwd=target_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if ret_val != 0:
+                process = subprocess.Popen([platform_binary('ant'), 'stress-build'], cwd=target_dir, env=env,
+                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 ret_val, _, _ = log_info(process, logger)
                 if ret_val is not 0:
                     raise CCMError("Error compiling Cassandra stress tool.  "

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -4,11 +4,234 @@ from six import StringIO
 
 import ccmlib
 from ccmlib.cluster import Cluster
+from ccmlib.common import _update_java_version
 from . import TEST_DIR, ccmtest
+from distutils.version import LooseVersion  # pylint: disable=import-error, no-name-in-module
 
 sys.path = [".."] + sys.path
 
 CLUSTER_PATH = TEST_DIR
+
+
+class TestUpdateJavaVersion(ccmtest.Tester):
+    def test_update_java_version(self):
+        # Tests for C*-4.0 (Java 8 or 11 or newer)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_1',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_2',
+                                          os_env={'X': '1'})
+        self.assertEqual({'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_3',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_4',
+                                          os_env={'X': '1'})
+        self.assertEqual({'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_5',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_6',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_7',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_8',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_9',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=8,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_10',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=11,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_4.0_11',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'PATH': '/some/bin:/opt/foo/java_home11/bin',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11'},
+                                          for_build=False, info_message='test_update_java_version_4.0_12',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin:/opt/foo/java_home11/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        # Tests for pre-C*-4.0 (Java 8 only)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_1',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_2',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11',
+                          'PATH': '/some/bin'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_3',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'PATH': '/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home11',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_4',
+                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
+                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
+
+        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
+                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
+                                          env={'JAVA_HOME': '/opt/foo/java_home8',
+                                               'JAVA8_HOME': '/opt/foo/java_home8',
+                                               'JAVA11_HOME': '/opt/foo/java_home11',
+                                               'PATH': '/some/bin'},
+                                          for_build=True, info_message='test_update_java_version_3.11_5',
+                                          os_env={'X': '1'})
+        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
+                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
+                          'JAVA8_HOME': '/opt/foo/java_home8',
+                          'JAVA11_HOME': '/opt/foo/java_home11'},
+                         result_env)
 
 
 class TestCCMLib(ccmtest.Tester):
@@ -28,7 +251,7 @@ class TestCCMLib(ccmtest.Tester):
         self.cluster.show(True)
         self.cluster.show(False)
 
-        #self.cluster.stress([])
+        # self.cluster.stress([])
         self.cluster.compact()
         self.cluster.drain()
         self.cluster.stop()
@@ -84,6 +307,7 @@ class TestRunCqlsh(ccmtest.Tester):
 
         if return_output and show_output:
             self.assertEqual(printed_output, rv[0])
+
 
 class TestNodeLoad(ccmtest.Tester):
 


### PR DESCRIPTION
Also:
* Add a new "version source type" `clone:/path/to/local/cassandra/clone` to re-enable upgrade-dtests for dev-CI and local upgrade-dtest runs after CASSANDRA-14420 + CASSANDRA-14421
* Introduce new node startup logfiles for stdout+stderr
* Use `./gradlew` instead of `ant` to build C*, if `gradlew` is present