### PR TITLE
STAR-57. Check if pid is alive while waiting for logs

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -19,6 +19,7 @@ import sys
 import time
 from distutils.version import LooseVersion  #pylint: disable=import-error, no-name-in-module
 
+import six
 import yaml
 from six import print_
 
@@ -452,12 +453,7 @@ def get_stress_bin(install_dir):
         add_exec_permission(path, short_bin)
     elif not os.access(stress, os.X_OK):
         try:
-            # try to add user execute permissions
-            # os.chmod doesn't work on Windows and isn't necessary unless in cygwin...
-            if sys.platform == "cygwin":
-                add_exec_permission(path, stress)
-            else:
-                os.chmod(stress, os.stat(stress).st_mode | stat.S_IXUSR)
+            os.chmod(stress, os.stat(stress).st_mode | stat.S_IXUSR)
         except:
             raise Exception("stress binary is not executable: %s" % (stress,))
 
@@ -546,7 +542,6 @@ def check_socket_listening(itf, timeout=60):
                 sock.close()
             # Try again in another 200ms
             time.sleep(.2)
-            continue
 
     return False
 
@@ -885,13 +880,12 @@ def merge_configuration(original, changes, delete_empty=True, delete_always=Fals
     return new
 
 
+def is_int_not_bool(obj):
+    return isinstance(obj, six.integer_types) and not isinstance(obj, bool)
+
+
 def is_intlike(obj):
-    try:
-        int(obj)
-        return True
-    except TypeError:
-        return False
-    raise RuntimeError('Reached end of {}; should not be possible'.format(is_intlike.__name__))
+    return isinstance(obj, six.integer_types)
 
 
 def wait_for_any_log(nodes, pattern, timeout, filename='system.log', marks=None):

--- a/tests/ccmtest.py
+++ b/tests/ccmtest.py
@@ -4,17 +4,20 @@ from unittest import TestCase
 
 class Tester(TestCase):
 
+    check_log_errors = True
+
     def __init__(self, *argv, **kwargs):
         super(Tester, self).__init__(*argv, **kwargs)
 
     def setUp(self):
-        pass
+        self.check_log_errors = True
 
     def tearDown(self):
         if hasattr(self, 'cluster'):
             try:
-                for node in self.cluster.nodelist():
-                    self.assertListEqual(node.grep_log_for_errors(), [])
+                if self.check_log_errors:
+                    for node in self.cluster.nodelist():
+                        self.assertListEqual(node.grep_log_for_errors(), [])
             finally:
                 test_path = self.cluster.get_path()
                 self.cluster.remove()


### PR DESCRIPTION
Rationale:
When starting C* ccm checks logs, waiting for particular phrases.
We want to fail test asap if there is a problem with node start.

Before:
If there is any problem with node start it will not happen and start() will hit timeout, by default 90s.
So the test will fail after 90s while it actually fail after 5s.

After:
If logs are streamed ccm will check if node pid is still alive.
If not it will immediately raise `NodeError` to fail test telling that node is not started correctly.

Note: 
this may break some tests, that are testing node start failure by expecting `TimeoutError`.
Such tests should be adjusted, but there should be only a few.

8ba2709f9c4080f18229513d0b9d8bd028bd98c3 is about some refactoring
8a960d9b6473d941d3dc687bee04c3a6ac133f9e is the change
