### PR TITLE
Use NODE_WAIT_TIMEOUT for log watch

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -636,31 +636,38 @@ class Node(object):
         log for 'Starting listening for CQL clients' before checking for the
         interface to be listening.
 
-        Emits a warning if not listening after NODE_WAIT_TIMEOUT_IN_SECS seconds.
+        Emits a warning if not listening after given timeout (default NODE_WAIT_TIMEOUT_IN_SECS) in seconds.
         """
+        timeout = kwargs.get('timeout', NODE_WAIT_TIMEOUT_IN_SECS)
+        kwargs['timeout'] = timeout
+
         if self.cluster.version() >= '1.2':
             self.watch_log_for("Starting listening for CQL clients", **kwargs)
 
         binary_itf = self.network_interfaces['binary']
-        if not common.check_socket_listening(binary_itf, timeout=NODE_WAIT_TIMEOUT_IN_SECS):
+        if not common.check_socket_listening(binary_itf, timeout=timeout):
             warnings.warn("Binary interface %s:%s is not listening after %s seconds, node may have failed to start."
-                          % (binary_itf[0], binary_itf[1], NODE_WAIT_TIMEOUT_IN_SECS))
+                          % (binary_itf[0], binary_itf[1], timeout))
 
     def wait_for_thrift_interface(self, **kwargs):
         """
         Waits for the Thrift interface to be listening.
 
-        Emits a warning if not listening after NODE_WAIT_TIMEOUT_IN_SECS seconds.
+        Emits a warning if not listening after given timeout (default NODE_WAIT_TIMEOUT_IN_SECS) in seconds.
         """
         if self.cluster.version() >= '4':
-            return;
+            return
+
+        timeout = kwargs.get('timeout', NODE_WAIT_TIMEOUT_IN_SECS)
+        kwargs['timeout'] = timeout
 
         self.watch_log_for("Listening for thrift clients...", **kwargs)
 
         thrift_itf = self.network_interfaces['thrift']
-        if not common.check_socket_listening(thrift_itf, timeout=NODE_WAIT_TIMEOUT_IN_SECS):
+        if not common.check_socket_listening(thrift_itf, timeout=timeout):
             warnings.warn(
-                "Thrift interface {}:{} is not listening after {} seconds, node may have failed to start.".format(thrift_itf[0], thrift_itf[1], NODE_WAIT_TIMEOUT_IN_SECS))
+                "Thrift interface {}:{} is not listening after {} seconds, node may have failed to start.".format(
+                    thrift_itf[0], thrift_itf[1], timeout))
 
     def get_launch_bin(self):
         cdir = self.get_install_dir()

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -265,6 +265,20 @@ class TestCCMLib(ccmtest.Tester):
         self.cluster.clear()
         self.cluster.stop()
 
+    def test_node_start_with_non_default_timeout(self):
+        self.cluster = Cluster(CLUSTER_PATH, "nodestarttimeout", cassandra_version='git:trunk')
+        self.cluster.populate(1)
+        node = self.cluster.nodelist()[0]
+
+        try:
+            node.start(wait_for_binary_proto=0)
+            self.fail("timeout expected with 0s startup timeout")
+        except ccmlib.node.TimeoutError:
+            pass
+        finally:
+            self.cluster.cleanup()
+            self.cluster.clear()
+            self.cluster.stop()
 
 class TestRunCqlsh(ccmtest.Tester):
 


### PR DESCRIPTION
Before: wait up to 600s for "Starting" msg in logs, then configured timeout for port open
After: wait up to timeout for "Starting" msg in logs then up to timeout for port open

It also brings back the ability to provide timeout in seconds instead of boolean for the `Node::start()` method.

Validation:
https://ci-cassandra.apache.org/blue/organizations/jenkins/Cassandra-devbranch/detail/Cassandra-devbranch/307/pipeline
https://ci-cassandra.apache.org/job/Cassandra-devbranch-dtest-upgrade/13/

And with fixes to extend timeouts for bootstrap or node replacement tests:
https://ci-cassandra.apache.org/blue/organizations/jenkins/Cassandra-devbranch/detail/Cassandra-devbranch/308/pipeline :ok:
https://ci-cassandra.apache.org/job/Cassandra-devbranch-dtest-upgrade/14/ :ok: