### PR TITLE
Use https for cloning github Cassandra repos

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -467,7 +467,7 @@ def github_username_and_branch_name(version):
 
 
 def github_repo_for_user(username):
-    return 'git@github.com:{username}/cassandra.git'.format(username=username)
+    return 'https://github.com/{username}/cassandra.git'.format(username=username)
 
 
 def version_directory(version):


### PR DESCRIPTION
I get failures when trying to use github forks as cassandra version due to some git shenanigans.
Works flawlessly with https though so it would be good to move to it as a default I guess.