### PR TITLE
adding more (debug) logs to make ccm more (new) user friendly …

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -762,6 +762,7 @@ class Cluster(object):
         extension.append_to_cluster_config(self, config_map)
         with open(filename, 'w') as f:
             yaml.safe_dump(config_map, f)
+            common.debug("{} was updated.".format(filename))
 
     def __update_pids(self, started):
         for node, p, _ in started:

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -18,6 +18,7 @@ class ClusterFactory():
     def load(path, name):
         cluster_path = os.path.join(path, name)
         filename = os.path.join(cluster_path, 'cluster.conf')
+        common.debug("Loading {} ...".format(filename))
         with open(filename, 'r') as f:
             data = yaml.safe_load(f)
         try:

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -71,6 +71,8 @@ class Cmd(object):
         else:
             self.path = options.config_dir
 
+        common.debug("Using ccm data and config path {} ...".format(self.path))
+
         if cluster_name:
             if len(args) == 0:
                 print_('Missing cluster name', file=sys.stderr)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -181,8 +181,10 @@ def get_user_home():
 def get_config():
     config_path = os.path.join(get_default_path(), CONFIG_FILE)
     if not os.path.exists(config_path):
+        common.debug("Config file does not exist at {}.".format(config_path))
         return {}
 
+    common.debug("Loading config file from {} ...".format(config_path))
     with open(config_path, 'r') as f:
         return yaml.safe_load(f)
 

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -35,8 +35,12 @@ GIT_REPO = "https://gitbox.apache.org/repos/asf/cassandra.git"
 GITHUB_REPO = "https://github.com/apache/cassandra.git"
 GITHUB_TAGS = "https://api.github.com/repos/apache/cassandra/git/refs/tags"
 CCM_CONFIG = ConfigParser.RawConfigParser()
-CCM_CONFIG.read(os.path.join(os.path.expanduser("~"), ".ccm", "config"))
-
+config_path = os.path.join(os.path.expanduser("~"), ".ccm", "config")
+read_ok = CCM_CONFIG.read(config_path)
+if len(read_ok) == 0:
+    common.debug("Config file {} was not found or could not be read.".format(config_path))
+else:
+    common.debug("Config file {} was successfully read.".format(config_path))
 
 def setup(version, verbose=False):
     binary = True
@@ -112,6 +116,8 @@ def setup(version, verbose=False):
                 return (version_directory(version), None)
             else:
                 raise e
+    else:
+        common.debug("Cassandra version was found in {}, no need to download.".format(cdir))
     return (cdir, version)
 
 
@@ -289,6 +295,7 @@ def download_dse_version(version, username, password, verbose=False):
         tar.extractall(path=__get_dir())
         tar.close()
         target_dir = os.path.join(__get_dir(), version)
+        common.debug("Moving extracted files to {} ...".format(target_dir))
         if os.path.exists(target_dir):
             rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
@@ -319,6 +326,7 @@ def download_opscenter_version(version, username, password, target_version, verb
         tar.extractall(path=__get_dir())
         tar.close()
         target_dir = os.path.join(__get_dir(), target_version)
+        common.debug("Moving extracted files to {} ...".format(target_dir))
         if os.path.exists(target_dir):
             rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
@@ -353,6 +361,7 @@ def download_version(version, url=None, verbose=False, binary=False):
         tar.extractall(path=__get_dir())
         tar.close()
         target_dir = os.path.join(__get_dir(), version)
+        common.debug("Moving extracted files to {} ...".format(target_dir))
         if os.path.exists(target_dir):
             rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
@@ -476,10 +485,12 @@ def version_directory(version):
         try:
             validate_install_dir(dir)
             return dir
-        except ArgumentError:
+        except ArgumentError as e:
+            common.warning(e)
             rmdirs(dir)
             return None
     else:
+        common.debug("Directory {} for Cassandra version {} was not found.".format(dir, version))
         return None
 
 


### PR DESCRIPTION
… during at least the `create` and `remove` operations

As a new user I wished I could have a verbose mode where ccm could tell me where it is reading the configuration files from, where it stored the downloaded Cassandra version, where it searched again in my docker container and why it did not find it, etc.

So I added these (mostly) debug logs.

During this work I saw that the main config file may be actually read from 2 places? (get_config() at common.py and at the beginning of repository.py (duplication and responsibility problem?)), but addressing that is not in the scope of this PR.