### PR TITLE
Helper script to provision a CCM cluster in MacOS

### DIFF
--- a/misc/ccm-macos.bash
+++ b/misc/ccm-macos.bash
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+CLUSTER_NAME=${CLUSTER_NAME:-test}
+NUM_NODES=${NUM_NODES:-3}
+CASSANDRA_DIR=${CASSANDRA_DIR:-$HOME/cassandra}
+PYTHON_VERSION=${PYTHON_VERSION:-python3}
+
+function fail()
+{
+    echo "ERROR: $1"
+    exit 1
+}
+
+
+if [ ! -z $VIRTUAL_ENV ]; then
+    if [ ! -d ${CASSANDRA_DIR}/pylib/venv ]; then
+
+        if [ "${PYTHON_VERSION}" != "python3" -a "${PYTHON_VERSION}" != "python2" ]; then
+            fail "Specify Python version python3 or python2"
+        fi
+
+        # Initialize the virtualenv used for Cassandra's pylib
+        virtualenv --python=$PYTHON_VERSION ${CASSANDRA_DIR}/pylib/venv
+        source ${CASSANDRA_DIR}/pylib/venv/bin/activate
+        pip install -r ${CASSANDRA_DIR}/pylib/requirements.txt
+        pip freeze
+    else
+        # use Cassandra's pylib virtual environment
+        source ${CASSANDRA_DIR}/pylib/venv/bin/activate
+    fi
+fi
+
+ccm remove $CLUSTER_NAME
+
+for i in $(seq 1 $(($NUM_NODES - 1)));
+do
+    if=127.0.0.$((i + 1))
+    echo $if
+    if ! ifconfig lo0 | grep "$if" > /dev/null; then
+        echo "Configuring interface $if"
+        sudo ifconfig lo0 alias $if || fail "Unable to configure interface $if"
+    fi
+done
+
+ccm create $CLUSTER_NAME -n $NUM_NODES --install-dir=${CASSANDRA_DIR}
+ccm populate -d -n $NUM_NODES
+ccm start


### PR DESCRIPTION
The ccm-macos.bash script allows the creation of a CCM cluster. It supports the `NUM_NODES`
parameter to determine the number of nodes to configure in the cluster. Additionally, it will
configure the required interfaces required for the cluster to start up. It requires `sudo` for
the operation, so this script will need elevated privileges to configure the interfaces
required.

Additionally, this script relies on a configured virtualenv. Conveniently, it can leverage
Cassandra's pylib virtualenv. If the virtualenv is not loaded, it will check whether
Cassandra's pylib virtualenv has been already initialized. If so, then it will activate the
virtualenv. Otherwise, it will initialize the virtualenv and install the requirements.

The name of the cluster defaults to `test`, but it can be configured by providing the
`CLUSTER_NAME` parameter.