### PR TITLE
Add post release version suffix so CI jobs update installed deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,3 @@ packages =
     ccmlib
     ccmlib.cmds
 
-[entry_points]
-console_scripts = 
-    cmd = ccm:main

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from platform import system
 from shutil import copyfile
 
 try:
@@ -7,9 +8,14 @@ try:
 except ImportError:
     from distutils.core import setup
 
-copyfile('ccm', 'ccm.py')
+ccmscript = 'ccm'
+
+if system() == "Windows":
+    copyfile('ccm', 'ccm.py')
+    ccmscript = 'ccm.py'
 
 setup(
     setup_requires=['pbr>=5.8.1'],
+    scripts=[ccmscript],
     pbr=True,
 )


### PR DESCRIPTION
After merging, if we redo the `cassandra-test` tag, CI builds should start to upgrade correctly