### PR TITLE
Fix Java version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ CCM you are running points to the code you are actively working on. There is no 
 are editing the Python files being run every time you invoke CCM.
 
 Almost there. Now you just need to add the test dependencies that are not in `requirements.txt`.
-`pip install mock pytest` to finish setting up your dev environment!
+`pip install mock pytest requests` to finish setting up your dev environment!
 
 Another caveat that has recently appeared Cassandra versions 4.0 and below ship with a version of JNA that isn't
 compatible with Apple Silicon and there are no plans to update JNA on those versions. One work around if you are

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -485,6 +485,7 @@ class ClusterStartCmd(Cmd):
         (['--profile-opts'], {'type': "string", 'action': "store", 'dest': "profile_options", 'help': "Yourkit options when profiling", 'default': None}),
         (['--quiet-windows'], {'action': "store_true", 'dest': "quiet_start", 'help': "Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", 'default': False}),
         (['--root'], {'action': "store_true", 'dest': "allow_root", 'help': "Allow CCM to start cassandra as root", 'default': False}),
+        (['--jvm-version'], {'type': "int", 'dest': "jvm_version", 'help': "Specify the JVM version to use (e.g. 8 for Java 8)", 'default': None}),
     ]
     descr_text = "Start all the non started nodes of the current cluster"
     usage = "usage: ccm cluster start [options]"
@@ -516,7 +517,8 @@ class ClusterStartCmd(Cmd):
                                   jvm_args=self.options.jvm_args,
                                   profile_options=profile_options,
                                   quiet_start=self.options.quiet_start,
-                                  allow_root=self.options.allow_root) is None:
+                                  allow_root=self.options.allow_root,
+                                  jvm_version=self.options.jvm_version) is None:
                 details = ""
                 if not self.options.verbose:
                     details = " (you can use --verbose for more information)"

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -160,6 +160,7 @@ class NodeStartCmd(Cmd):
         (['--jvm_arg'], {'action': "append", 'dest': "jvm_args", 'help': "Specify a JVM argument", 'default': []}),
         (['--quiet-windows'], {'action': "store_true", 'dest': "quiet_start", 'help': "Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", 'default': False}),
         (['--root'], {'action': "store_true", 'dest': "allow_root", 'help': "Allow CCM to start cassandra as root", 'default': False}),
+        (['--jvm-version'], {'type': "int", 'dest': "jvm_version", 'help': "Specify the JVM version to use (e.g. 8 for Java 8)", 'default': None}),
     ]
     descr_text = "Start a node"
     usage = "usage: ccm node start [options] name"
@@ -177,7 +178,8 @@ class NodeStartCmd(Cmd):
                             replace_address=self.options.replace_address,
                             jvm_args=self.options.jvm_args,
                             quiet_start=self.options.quiet_start,
-                            allow_root=self.options.allow_root)
+                            allow_root=self.options.allow_root,
+                            jvm_version=self.options.jvm_version)
         except NodeError as e:
             print_(str(e), file=sys.stderr)
             print_("Standard error output is:", file=sys.stderr)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -840,7 +840,7 @@ def get_jdk_version(process='java'):
     try:
         version = subprocess.check_output([process, '-version'], stderr=subprocess.STDOUT)
     except OSError:
-        print_("ERROR: Could not find java. Is it in your path?")
+        print_("ERROR: Could not find {}. Is it in your path?".format(process))
         exit(1)
 
     return _get_jdk_version(version)
@@ -931,15 +931,21 @@ def _update_java_version(current_java_version, current_java_home_version,
 
     # Determine "versions" - supported Java versions for select Cassandra distribution
     # First - attempt to get the supported Java versions from the Cassandra distribution
-    build_versions = get_supported_jdk_versions(install_dir)
+    build_versions = None
+    if install_dir:
+        build_versions = get_supported_jdk_versions(install_dir)
     run_versions = build_versions
 
     # If the supported Java versions are not available from the distribution, use the known defaults
+
+    if cassandra_version and not isinstance(cassandra_version, LooseVersion):
+        cassandra_version = LooseVersion(cassandra_version)
+
     if build_versions is None:
-        if cassandra_version >= '5.0':
+        if cassandra_version and cassandra_version >= LooseVersion('5.0'):
             build_versions = [11, 17]
             run_versions = [11, 17]
-        elif cassandra_version >= '4.0':
+        elif cassandra_version and cassandra_version >= LooseVersion('4.0'):
             if not os_env:
                 os_env = os.environ
             if 'CASSANDRA_USE_JDK11' not in os_env:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -854,38 +854,53 @@ def _get_jdk_version(version):
     ver_pattern = '\"(\d+).*\"'
     return re.search(ver_pattern, str(version)).groups()[0] + ".0"
 
+
+def get_supported_jdk_versions_internal(path, pattern):
+    if os.path.exists(path):
+        with open(path) as f:
+            for line in f:
+                match = re.search(pattern, line)
+                if match:
+                    versions = match.group(1).split(',')
+                    versions = [8 if v == '1.8' else int(v) for v in versions]
+                    return versions
+    return None
+
+
 def get_supported_jdk_versions(install_dir):
     """
-    Return the supported java versions from build.xml
-    Only works in > 4.1
+    Return the supported Java versions from build.xml (source distributions)
+    or from cassandra.in.sh (binary distributions) if such information is present (5.0+ for source, 5.1+ for binary).
     """
-    build = os.path.join(install_dir, 'build.xml')
-    with open(build) as f:
-        for line in f:
-            match = re.search('name="java\.supported" value="([0-9.,]+)"', line)
-            if match:
-                versions = match.group(1).split(',')
-                versions = [8 if v == '1.8' else int(v) for v in versions]
-                return versions
-    raise ValueError("did not find java.supported in build.xml!")
+
+    # source distributions have supported Java versions specified in build.xml since 5.0
+    versions = get_supported_jdk_versions_internal(os.path.join(install_dir, 'build.xml'),
+                                                   'name="java\\.supported" value="([0-9.,]+)"')
+    if versions is None:
+        # binary distributions have supported Java versions specified in bin/cassandra.in.sh since 5.1
+        versions = get_supported_jdk_versions_internal(os.path.join(install_dir, 'bin', 'cassandra.in.sh'),
+                                                       'java_versions_supported=([0-9.,]+)')
+
+    info("Supported Java versions for Cassandra distribution in '{}': {}".format(install_dir, versions))
+
+    return versions
+
 
 def update_java_version(jvm_version=None, install_dir=None, cassandra_version=None, env=None,
                         for_build=False, info_message=None):
     """
-    Updates or fixes the Java version (JAVA_HOME environment).
-    If 'jvm_version' is explicitly set, that one will be used.
-    Otherwise, the Java version will be guessed from the provided 'cassandra_version' parameter.
-    If the version-parameters are not specified, those will be inquired from the 'install_dir'.
-    See CASSANDRA-15835
-    :param jvm_version: The Java version to use - must be the major Java version number like 8 or 11.
+    Selects Java distribution and returns the updated env (updates JAVA_HOME and PATH variables if needed).
+    If 'jvm_version' is explicitly set, that one will be used if a Java distribution of that version can be found.
+    Otherwise, the Java version will be guessed from the distribution provided by 'install_dir' parameter or from
+    the provided 'cassandra_version' parameter.
+    :param jvm_version: The explicit Java version to use - must be the major Java version number like 8 or 11 (int).
     :param install_dir: Software installation directory.
     :param cassandra_version: The Cassandra version to consider for choosing the correct Java version.
-    :param env: Current OS environment variables.
+    :param env: environment variables to update; if None, 'os.environ' is used.
     :param for_build: whether the code should check for a valid version to build or run bdp. Currently only
     applies to source tree that have a 'build-env.yaml' file.
     :param info_message: String logged with info/error messages
-    :return: the maybe updated OS environment variables. If 'env' was 'None' and JAVA_HOME needs to be set,
-    the result will also contain the current OS environment variables from 'os.environ'.
+    :return: the provided 'env' with updated JAVA_HOME and PATH variables if needed.
     """
 
     env = env if env else os.environ
@@ -905,6 +920,7 @@ def update_java_version(jvm_version=None, install_dir=None, cassandra_version=No
 def _update_java_version(current_java_version, current_java_home_version,
                          jvm_version=None, install_dir=None, cassandra_version=None, env=None,
                          for_build=False, info_message=None, os_env=None):
+
     # Internal variant accessible for tests
 
     if env is None:
@@ -913,74 +929,88 @@ def _update_java_version(current_java_version, current_java_home_version,
     if cassandra_version is None and install_dir:
         cassandra_version = get_version_from_build(install_dir)
 
-    # conservative Java version defaults
-    # Cassandra versions 3.x and 2.x use the defaults
-    build_versions = [8]
-    run_versions = [8]
+    # Determine "versions" - supported Java versions for select Cassandra distribution
+    # First - attempt to get the supported Java versions from the Cassandra distribution
+    build_versions = get_supported_jdk_versions(install_dir)
+    run_versions = build_versions
 
-    info(
-        '{}: current_java_version={}, current_java_home_version={}, jvm_version={}, for_build={}, cassandra_version={}, install_dir={}, env={}'
-        .format(info_message, current_java_version, current_java_home_version, jvm_version, for_build,
-                cassandra_version, install_dir, env))
-
-    # this won't work with DSE versions
-    if cassandra_version >= '4.2':
-        if os.path.exists(os.path.join(install_dir, 'build.xml')):
-            build_versions = get_supported_jdk_versions(install_dir)
-            run_versions = get_supported_jdk_versions(install_dir)
+    # If the supported Java versions are not available from the distribution, use the known defaults
+    if build_versions is None:
+        if cassandra_version >= '5.0':
+            build_versions = [11, 17]
+            run_versions = [11, 17]
+        elif cassandra_version >= '4.0':
+            if not os_env:
+                os_env = os.environ
+            if 'CASSANDRA_USE_JDK11' not in os_env:
+                build_versions = [8, 11]
+                run_versions = [8, 11]
+            else:
+                build_versions = [11]
+                run_versions = [11]
         else:
-            # binary installs we don't know which jdks are supported any more
-            build_versions = [current_java_version]
-            run_versions = [current_java_version]
+            # Cassandra versions 3.x and 2.x
+            build_versions = [8]
+            run_versions = [8]
 
-    if '4.0' <= cassandra_version < '4.2':
-        if not os_env:
-            os_env = os.environ
-        if 'CASSANDRA_USE_JDK11' not in os_env:
-            build_versions = [8, 11]
-            run_versions = [8, 11, 12, 13, 14, 15, 16, 17]
-        else:
-            build_versions = [11]
-            run_versions = [11]
+    # Java versions supported by the Cassandra distribution
+    supported_versions = build_versions if for_build else run_versions
 
-    versions = build_versions if for_build else run_versions
+    # Java versions available in the current environment (JAVA_HOME, JAVAn_HOME)
+    available_versions = {get_jdk_version_int(os.path.join(env_value, 'bin', 'java')): env_key
+                          for env_key, env_value in env.items() if re.search("JAVA([0-9]+)?_HOME", env_key)}
 
+    # Intersection of supported and available Java versions
+    supported_available_versions = {v for v in supported_versions if v in available_versions}
+
+    info('{}: current_java_version={}, current_java_home_version={}, (explicit) jvm_version={}, for_build={}, '
+         'supported java versions={}, available java versions={}, cassandra_version={}, install_dir={}, env={}'
+         .format(info_message, current_java_version, current_java_home_version, jvm_version, for_build,
+                 supported_versions, available_versions, cassandra_version, install_dir,
+                 {k: v for k, v in env.items() if k.startswith('JAVA') or k == 'PATH'}))
+
+    # Determine "jvm_version" - exact Java version to use if it was not explicitly provided
     if not jvm_version:
-        if current_java_version in versions:
+        # First attempt to use the current Java from the PATH if it is supported
+        if current_java_version in supported_available_versions:
             jvm_version = current_java_version
-        else:
-            for version in versions:
-                if 'JAVA{}_HOME'.format(version) in env:
-                    jvm_version = version
-                    break
 
-        if jvm_version:
-            info('{}: using Java {} for the current invocation'
-                 .format(info_message, jvm_version))
+        # If the current Java from the PATH is not supported or available, select the lowest supported and available one
+        elif len(supported_available_versions) > 0:
+            jvm_version = sorted(supported_available_versions, reverse=False)[0]
+            info("{}: Selected Java version {} based on the available {} env variable because the current Java "
+                 "version {} is not supported by Cassandra {} (supported versions: {})."
+                 .format(info_message, jvm_version, available_versions[jvm_version],
+                         current_java_version, cassandra_version, supported_versions))
+
+        # If there is no supported Java versions available in the current env, forcibly select the current Java version
+        # from the PATH if it is available, and show an appropriate warning message
+        elif current_java_version in available_versions:
+            jvm_version = current_java_version
+            warning('{}: cannot find a suitable Java version for the current invocation. '
+                    'Forcibly using current_java_version={}'
+                    .format(info_message, current_java_version))
+
+        # If neither any supported version nor the current Java version is available in the current env, fail
+        else:
+            raise RuntimeError('{}: cannot find any Java distribution for the current invocation.'.format(info_message))
+
     else:
-        # Called proved an explicit Java version
         info('{}: Using explicitly requested Java version {} for the current invocation of Cassandra {}'
              .format(info_message, jvm_version, cassandra_version))
+        if jvm_version not in available_versions:
+            raise RuntimeError('{}: The explicitly requested Java version {} is not available in the current env.'
+                               .format(info_message, jvm_version))
+        if jvm_version not in supported_versions:
+            warning('{}: The explicitly requested Java version {} is not supported by Cassandra {}.'
+                    .format(info_message, jvm_version, cassandra_version))
 
-    # If the 'java' binary accessible via PATH points to a different Java version than the current JAVA_HOME,
-    # update it to point to the Java version of the 'java' binary accessible via PATH.
-    # Need to do this, because ccmlib.common.compile_version() uses the 'java' binary accessible via PATH via 'ant'.
-    if not jvm_version:
-        if current_java_home_version != current_java_version:
-            jvm_version = current_java_version
-            info('{}: Using Java {} for Cassandra {}, because the Java versions of java binary in PATH ({}) and '
-                 'JAVA_HOME ({}) did not match'.format(info_message, current_java_version, cassandra_version,
-                                                       current_java_version, current_java_home_version))
-        else:
-            jvm_version = current_java_version
-
-    if current_java_version != jvm_version or current_java_home_version != jvm_version:
-        new_java_home = 'JAVA{}_HOME'.format(jvm_version)
-        if new_java_home not in env:
-            raise RuntimeError("{}: You need to set JAVA{}_HOME to run Cassandra {}"
-                               .format(info_message, jvm_version, cassandra_version))
-        env['JAVA_HOME'] = env[new_java_home]
-        env['PATH'] = '{}/bin:{}'.format(env[new_java_home], env['PATH'] if 'PATH' in env else '')
+    env['JAVA_HOME'] = env[available_versions[jvm_version]]
+    path = env['PATH'] if 'PATH' in env else ''
+    path_entry = '{}/bin:'.format(env[available_versions[jvm_version]])
+    if not path.startswith(path_entry):
+        path = path_entry + path
+    env['PATH'] = path
     return env
 
 

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -72,13 +72,13 @@ class DseCluster(Cluster):
     def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None,derived_cassandra_version=None):
         return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, derived_cassandra_version=derived_cassandra_version)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False, jvm_version=None):
         if jvm_args is None:
             jvm_args = []
         marks = {}
         for node in self.nodelist():
             marks[node] = node.mark_log()
-        started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options, quiet_start=quiet_start, allow_root=allow_root, timeout=180)
+        started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options, quiet_start=quiet_start, allow_root=allow_root, timeout=180, jvm_version=jvm_version)
         self.start_opscenter()
         if self._misc_config_options.get('enable_aoss', False):
             self.wait_for_any_log('AlwaysOn SQL started', 600, marks=marks)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -239,7 +239,7 @@ class Node(object):
         env = common.make_cassandra_env(self.get_install_dir(), self.get_path(), update_conf)
         env = common.update_java_version(jvm_version=None,
                                          install_dir=self.get_install_dir(),
-                                         cassandra_version=self.cluster.cassandra_version(),
+                                         cassandra_version=self.get_cassandra_version(),
                                          env=env,
                                          info_message=self.name)
         for (key, value) in self.__environment_variables.items():

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -111,7 +111,7 @@ class TestUpdateJavaVersion(ccmtest.Tester):
             result_env = _update_java_version(current_java_version=cur_java_version, current_java_home_version=None,
                                               jvm_version=java_version, install_dir=None, cassandra_version=LooseVersion(cassandra_version),
                                               env=self._make_env(), for_build=True,
-                                              info_message='test_default_selection_{}'.format(cassandra_version), os_env={})
+                                              info_message='test_default_selection_{}'.format(cassandra_version), os_env={'key':'value'})
             self._check_env(result_env, expected_java_version)
 
     def test_update_java_version(self):

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,14 +1,18 @@
+import os
 import sys
+import tempfile
 import time
+from distutils.version import LooseVersion  # pylint: disable=import-error, no-name-in-module
+from pathlib import Path
 
+import requests
 from six import StringIO
 
 import ccmlib
 from ccmlib.cluster import Cluster
-from ccmlib.common import _update_java_version
+from ccmlib.common import _update_java_version, get_supported_jdk_versions
 from ccmlib.node import NodeError
 from . import TEST_DIR, ccmtest
-from distutils.version import LooseVersion  # pylint: disable=import-error, no-name-in-module
 
 sys.path = [".."] + sys.path
 
@@ -16,224 +20,239 @@ CLUSTER_PATH = TEST_DIR
 
 
 class TestUpdateJavaVersion(ccmtest.Tester):
+    env = dict()
+    temp_dir = None
+
+    # prepare for tests
+    def setUp(self):
+        # create a directory in temp location
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+        # create fake java distribution directories for 7, 8, 11, 17, and 21 in temp directory
+        for jvm_version in [7, 8, 11, 17, 21]:
+            path = self.temp_dir.name + '/java{}'.format(jvm_version)
+            Path(path + '/bin').mkdir(parents=True, exist_ok=True)
+            # create java executable with a script returning java version
+            full_version = '{}.0.{}'.format(jvm_version, jvm_version * 2)
+            build_version = jvm_version * 3
+            with open(path + '/bin/java', 'w') as f:
+                f.write('#!/bin/bash\n')
+                # there must be an only parameter '-version' in the command line
+                f.write('if [ "$1" != "-version" ]; then\n')
+                f.write('  exit 1\n')
+                f.write('fi\n')
+                f.write('echo \'openjdk version "{}" 2023-04-18\'\n'.format(full_version))
+                f.write('echo \'OpenJDK Runtime Environment Temurin-{}+{} (build {}+{})\'\n'.format(full_version, build_version, full_version, build_version))
+                f.write('echo \'OpenJDK 64-Bit Server VM Temurin-{}+{} (build {}+{}, mixed mode)\'\n'.format(full_version, build_version, full_version, build_version))
+            # make the script executable
+            os.chmod(path + '/bin/java', 0o755)
+            self.env['JAVA{}_HOME'.format(jvm_version)] = path
+
+    def _make_cassandra_install_dir(self, git_branch, is_source_dist):
+        dist_dir = '{}/cassandra/{}'.format(self.temp_dir.name, git_branch)
+        Path(dist_dir + "/bin").mkdir(parents=True, exist_ok=True)
+
+        if is_source_dist:
+            if not Path(dist_dir + '/build.xml').exists():
+                with open(dist_dir + '/build.xml', 'w') as f:
+                    r = requests.get('https://raw.githubusercontent.com/apache/cassandra/{}/build.xml'.format(git_branch))
+                    f.write(r.text)
+        else:
+            if Path(dist_dir + '/build.xml').exists():
+                os.remove(dist_dir + '/build.xml')
+
+        if not Path(dist_dir + '/bin/cassandra.in.sh').exists():
+            with open(dist_dir + '/bin/cassandra.in.sh', 'w') as f:
+                r = requests.get('https://raw.githubusercontent.com/apache/cassandra/{}/bin/cassandra.in.sh'.format(git_branch))
+                f.write(r.text)
+
+        return dist_dir
+
+    def _make_env(self, java_home_version = None, path = '/some/bin', include_homes = None):
+        env = dict()
+        if include_homes:
+            for v in include_homes:
+                key = 'JAVA{}_HOME'.format(v)
+                env[key] = self.env[key]
+        else:
+            env = self.env.copy()
+        if java_home_version is not None:
+            env['JAVA_HOME'] = self.env['JAVA{}_HOME'.format(java_home_version)]
+        if path is not None:
+            env['PATH'] = path
+        return env
+
+    def _check_env(self, result_env, expected_java_version):
+        self.assertIn('JAVA_HOME', result_env)
+        self.assertIn('PATH', result_env)
+        self.assertEqual(result_env['JAVA_HOME'], self.env['JAVA{}_HOME'.format(expected_java_version)])
+        self.assertIn('{}/bin:/some/bin'.format(self.env['JAVA{}_HOME'.format(expected_java_version)]), result_env['PATH'])
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_get_supported_jdk_versions(self):
+        # we cannot assert anything about trunk except that we can figure out some versions
+        self.assertIsNotNone(get_supported_jdk_versions(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', False)))
+        self.assertIsNotNone(get_supported_jdk_versions(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', True)))
+
+        # some commit of Cassandra 5.1
+        self.assertEquals(get_supported_jdk_versions(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', False)), [11, 17])
+        self.assertEquals(get_supported_jdk_versions(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', True)), [11, 17])
+
+        self.assertIsNone(get_supported_jdk_versions(self._make_cassandra_install_dir('cassandra-5.0', False)))
+        self.assertEquals(get_supported_jdk_versions(self._make_cassandra_install_dir('cassandra-5.0', True)), [11, 17])
+
+        self.assertIsNone(get_supported_jdk_versions(self._make_cassandra_install_dir('cassandra-4.1', False)))
+        self.assertIsNone(get_supported_jdk_versions(self._make_cassandra_install_dir('cassandra-4.1', True)))
+
+    def _test_default_selection(self, expected_java_version, cur_java_version, java_version, cassandra_versions):
+        for cassandra_version in cassandra_versions:
+            result_env = _update_java_version(current_java_version=cur_java_version, current_java_home_version=None,
+                                              jvm_version=java_version, install_dir=None, cassandra_version=LooseVersion(cassandra_version),
+                                              env=self._make_env(), for_build=True,
+                                              info_message='test_default_selection_{}'.format(cassandra_version), os_env={})
+            self._check_env(result_env, expected_java_version)
+
     def test_update_java_version(self):
+        # just use the lowest supported and available
+        self._test_default_selection(8, None, None, ['2.2', '3.0', '3.1', '3.11', '4.0', '4.1'])
+        self._test_default_selection(11, None, None, ['5.0', '5.1'])
+
+        # prefer cur if supported and available
+        self._test_default_selection(8, 8, None, ['2.2', '3.0', '3.1', '3.11', '4.0', '4.1'])
+        self._test_default_selection(11, 8, None, ['5.0', '5.1'])
+        self._test_default_selection(8, 11, None, ['2.2', '3.0', '3.1', '3.11'])
+        self._test_default_selection(11, 11, None, ['4.0', '4.1', '5.0', '5.1'])
+        self._test_default_selection(8, 17, None, ['2.2', '3.0', '3.1', '3.11', '4.0', '4.1'])
+        self._test_default_selection(17, 17, None, ['5.0', '5.1'])
+
+        # forcibly select
+        self._test_default_selection(17, None, 17, ['2.2', '3.0', '3.1', '3.11', '4.0', '4.1', '5.0', '5.1'])
+        self._test_default_selection(17, 8, 17, ['2.2', '3.0', '3.1', '3.11', '4.0', '4.1', '5.0', '5.1'])
+
         # Tests for C*-4.0 (Java 8 or 11 or newer)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=11),
                                           for_build=True, info_message='test_update_java_version_4.0_1',
                                           os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
-                          'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'PATH': '/some/bin'},
+                                          env=self._make_env(),
                                           for_build=True, info_message='test_update_java_version_4.0_2',
                                           os_env={'X': '1'})
-        self.assertEqual({'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=8),
                                           for_build=True, info_message='test_update_java_version_4.0_3',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
-                          'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'PATH': '/some/bin'},
+                                          env=self._make_env(),
                                           for_build=True, info_message='test_update_java_version_4.0_4',
                                           os_env={'X': '1'})
-        self.assertEqual({'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=8),
                                           for_build=True, info_message='test_update_java_version_4.0_5',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=8),
                                           for_build=True, info_message='test_update_java_version_4.0_6',
                                           os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=8),
                                           for_build=True, info_message='test_update_java_version_4.0_7',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=11),
                                           for_build=True, info_message='test_update_java_version_4.0_8',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=11),
                                           for_build=True, info_message='test_update_java_version_4.0_9',
                                           os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=8,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=11),
                                           for_build=True, info_message='test_update_java_version_4.0_10',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=11,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=11),
                                           for_build=True, info_message='test_update_java_version_4.0_11',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=8, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'PATH': '/some/bin:/opt/foo/java_home11/bin',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11'},
+                                          env=self._make_env(java_home_version=11, path='/some/bin:/opt/foo/java_home11/bin'),
                                           for_build=False, info_message='test_update_java_version_4.0_12',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin:/opt/foo/java_home11/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 11)
 
         # Tests for pre-C*-4.0 (Java 8 only)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=11),
                                           for_build=True, info_message='test_update_java_version_3.11_1',
                                           os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
-                          'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=8),
                                           for_build=True, info_message='test_update_java_version_3.11_2',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=8),
                                           for_build=True, info_message='test_update_java_version_3.11_3',
                                           os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'PATH': '/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
                                           install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=11),
                                           for_build=True, info_message='test_update_java_version_3.11_4',
                                           os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 8)
 
         result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
                                           install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
+                                          env=self._make_env(java_home_version=8),
                                           for_build=True, info_message='test_update_java_version_3.11_5',
                                           os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        self._check_env(result_env, 11)
 
 
 class TestCCMLib(ccmtest.Tester):


### PR DESCRIPTION
Problem: for Cassandra 5 not built from the sources, Java version is not selected properly - it is assumed it works with either current version or Java 8.

Fixes:
- For Cassandra 5.1+ binary distribution, the supported versions are retrieved from cassandra.in.sh
- If supported Cassandra version cannot be retrieved from either build.xml (source dist) or cassandra.in.sh (bin dist), use the hardcoded version - the conditions cover all supported Cassandra versions starting from 2.2.
- Refactored Java selection logic - clearly distinguish supported Java versions by Cassandra and available Java versions in the environment (distributions configured via JAVA_HOME and JAVAn_HOME env variables); prioritizes the supported Java version over the current Java version configured via PATH (which is currently needed for upgrade testing)
- More explanatory messages about the Java version selection
- Added --jvm-version command line option for explicitly setting Java version with cluster or node start commands
- Fixed Cassandra version used to resolve Java version for running node tool (it was using Cassandra version defined for the cluster instead of the node which might have been upgraded)
