### PR TITLE
Cassandra 19636

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ CCM you are running points to the code you are actively working on. There is no 
 are editing the Python files being run every time you invoke CCM.
 
 Almost there. Now you just need to add the test dependencies that are not in `requirements.txt`.
-`pip install mock pytest` to finish setting up your dev environment!
+`pip install mock pytest requests` to finish setting up your dev environment!
 
 Another caveat that has recently appeared Cassandra versions 4.0 and below ship with a version of JNA that isn't
 compatible with Apple Silicon and there are no plans to update JNA on those versions. One work around if you are

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -485,6 +485,7 @@ class ClusterStartCmd(Cmd):
         (['--profile-opts'], {'type': "string", 'action': "store", 'dest': "profile_options", 'help': "Yourkit options when profiling", 'default': None}),
         (['--quiet-windows'], {'action': "store_true", 'dest': "quiet_start", 'help': "Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", 'default': False}),
         (['--root'], {'action': "store_true", 'dest': "allow_root", 'help': "Allow CCM to start cassandra as root", 'default': False}),
+        (['--jvm-version'], {'type': "int", 'dest': "jvm_version", 'help': "Specify the JVM version to use (e.g. 8 for Java 8)", 'default': None}),
     ]
     descr_text = "Start all the non started nodes of the current cluster"
     usage = "usage: ccm cluster start [options]"
@@ -516,7 +517,8 @@ class ClusterStartCmd(Cmd):
                                   jvm_args=self.options.jvm_args,
                                   profile_options=profile_options,
                                   quiet_start=self.options.quiet_start,
-                                  allow_root=self.options.allow_root) is None:
+                                  allow_root=self.options.allow_root,
+                                  jvm_version=self.options.jvm_version) is None:
                 details = ""
                 if not self.options.verbose:
                     details = " (you can use --verbose for more information)"

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -160,6 +160,7 @@ class NodeStartCmd(Cmd):
         (['--jvm_arg'], {'action': "append", 'dest': "jvm_args", 'help': "Specify a JVM argument", 'default': []}),
         (['--quiet-windows'], {'action': "store_true", 'dest': "quiet_start", 'help': "Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", 'default': False}),
         (['--root'], {'action': "store_true", 'dest': "allow_root", 'help': "Allow CCM to start cassandra as root", 'default': False}),
+        (['--jvm-version'], {'type': "int", 'dest': "jvm_version", 'help': "Specify the JVM version to use (e.g. 8 for Java 8)", 'default': None}),
     ]
     descr_text = "Start a node"
     usage = "usage: ccm node start [options] name"
@@ -177,7 +178,8 @@ class NodeStartCmd(Cmd):
                             replace_address=self.options.replace_address,
                             jvm_args=self.options.jvm_args,
                             quiet_start=self.options.quiet_start,
-                            allow_root=self.options.allow_root)
+                            allow_root=self.options.allow_root,
+                            jvm_version=self.options.jvm_version)
         except NodeError as e:
             print_(str(e), file=sys.stderr)
             print_("Standard error output is:", file=sys.stderr)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -825,7 +825,10 @@ def invalidate_cache():
 
 
 def get_jdk_version_int(process='java'):
-    jdk_version = float(get_jdk_version(process))
+    jdk_version_str = get_jdk_version(process)
+    if jdk_version_str is None:
+        return None
+    jdk_version = float(jdk_version_str)
     # Make it Java 8 instead of 1.8 (or 7 instead of 1.7)
     jdk_version = int(jdk_version if jdk_version >= 2 else 10 * (jdk_version - 1))
     return jdk_version
@@ -840,8 +843,8 @@ def get_jdk_version(process='java'):
     try:
         version = subprocess.check_output([process, '-version'], stderr=subprocess.STDOUT)
     except OSError:
-        print_("ERROR: Could not find java. Is it in your path?")
-        exit(1)
+        info("Could not find {}.".format(process))
+        return None
 
     return _get_jdk_version(version)
 
@@ -854,29 +857,86 @@ def _get_jdk_version(version):
     ver_pattern = '\"(\d+).*\"'
     return re.search(ver_pattern, str(version)).groups()[0] + ".0"
 
-def get_supported_jdk_versions(install_dir):
+
+def get_supported_jdk_versions_internal(path, pattern):
+    if os.path.exists(path):
+        with open(path) as f:
+            for line in f:
+                match = re.search(pattern, line)
+                if match:
+                    versions = match.group(1).split(',')
+                    versions = [8 if v == '1.8' else int(v) for v in versions]
+                    return versions
+    return None
+
+
+def get_supported_jdk_versions_from_dist(install_dir):
     """
-    Return the supported java versions from build.xml
-    Only works in > 4.1
+    Return the supported Java versions from build.xml (source distributions)
+    or from cassandra.in.sh (binary distributions) if such information is present (5.0+ for source, 5.1+ for binary).
     """
-    build = os.path.join(install_dir, 'build.xml')
-    with open(build) as f:
-        for line in f:
-            match = re.search('name="java\.supported" value="([0-9.,]+)"', line)
-            if match:
-                versions = match.group(1).split(',')
-                versions = [8 if v == '1.8' else int(v) for v in versions]
-                return versions
-    raise ValueError("did not find java.supported in build.xml!")
+
+    # source distributions have supported Java versions specified in build.xml since 5.0
+    versions = get_supported_jdk_versions_internal(os.path.join(install_dir, 'build.xml'),
+                                                   'name="java\\.supported" value="([0-9.,]+)"')
+    if versions is None:
+        # binary distributions have supported Java versions specified in bin/cassandra.in.sh since 5.1
+        versions = get_supported_jdk_versions_internal(os.path.join(install_dir, 'bin', 'cassandra.in.sh'),
+                                                       'java_versions_supported=([0-9.,]+)')
+
+    info("Supported Java versions for Cassandra distribution in '{}': {}".format(install_dir, versions))
+
+    return versions
+
+
+def get_supported_jdk_versions(cassandra_version, install_dir, for_build, env):
+    build_versions = None
+    if install_dir:
+        build_versions = get_supported_jdk_versions_from_dist(install_dir)
+    run_versions = build_versions
+
+    # If the supported Java versions are not available from the distribution, use the known defaults
+    if cassandra_version and not isinstance(cassandra_version, LooseVersion):
+        cassandra_version = LooseVersion(cassandra_version)
+
+    if build_versions is None:
+        if cassandra_version and cassandra_version >= LooseVersion('5.0'):
+            build_versions = [11, 17]
+            run_versions = [11, 17]
+        elif cassandra_version and cassandra_version >= LooseVersion('4.0'):
+            if 'CASSANDRA_USE_JDK11' not in env:
+                build_versions = [8, 11]
+                run_versions = [8, 11]
+            else:
+                build_versions = [11]
+                run_versions = [11]
+        else:
+            # Cassandra versions 3.x and 2.x
+            build_versions = [8]
+            run_versions = [8]
+
+    # Java versions supported by the Cassandra distribution
+    return build_versions if for_build else run_versions
+
+
+def get_available_jdk_versions(env):
+    return {get_jdk_version_int(os.path.join(env_value, 'bin', 'java')): env_key
+            for env_key, env_value in env.items() if re.search("JAVA([0-9]+)?_HOME", env_key)}
+
 
 def update_java_version(jvm_version=None, install_dir=None, cassandra_version=None, env=None,
                         for_build=False, info_message=None):
     """
-    Updates or fixes the Java version (JAVA_HOME environment).
-    If 'jvm_version' is explicitly set, that one will be used.
-    Otherwise, the Java version will be guessed from the provided 'cassandra_version' parameter.
-    If the version-parameters are not specified, those will be inquired from the 'install_dir'.
-    See CASSANDRA-15835
+    Updates or fixes the environment variables for Java distribution.
+    If 'jvm_version' is explicitly set, that one will be used as long as it can be found in the current environment
+    via JAVA_HOME and JAVAx_HOME variables.
+    Otherwise, the supported Java versions will be guessed from the provided `cassandra_version` (or install dir if None).
+    Then, if there is a JAVA_HOME variable set, that Java distribution will be used if it is supported by Cassandra.
+    If not, the closest supported Java version will be used from the available Java distributions (or the highest
+    supported version if JAVA_HOME is not defined).
+    Note that, if there is java command available on the PATH, it must be the same version as the Java distribution
+    defined in JAVA_HOME, otherwise an error will be raised as there is no obvious way to decide which one to use.
+
     :param jvm_version: The Java version to use - must be the major Java version number like 8 or 11.
     :param install_dir: Software installation directory.
     :param cassandra_version: The Cassandra version to consider for choosing the correct Java version.
@@ -884,8 +944,9 @@ def update_java_version(jvm_version=None, install_dir=None, cassandra_version=No
     :param for_build: whether the code should check for a valid version to build or run bdp. Currently only
     applies to source tree that have a 'build-env.yaml' file.
     :param info_message: String logged with info/error messages
-    :return: the maybe updated OS environment variables. If 'env' was 'None' and JAVA_HOME needs to be set,
-    the result will also contain the current OS environment variables from 'os.environ'.
+    :return: the maybe updated OS environment variables - the only variables that may get updated are PATH and JAVA_HOME.
+    If 'env' was 'None' and JAVA_HOME needs to be set, the result will also contain the current OS environment variables
+    from 'os.environ'.
     """
 
     env = env if env else os.environ
@@ -902,86 +963,86 @@ def update_java_version(jvm_version=None, install_dir=None, cassandra_version=No
                                 for_build=for_build, info_message=info_message)
 
 
+def update_path_in_env(env, path_entry):
+    path = env['PATH'] if 'PATH' in env else ''
+    if not path.startswith(path_entry):
+        path = '{}:{}'.format(path_entry, path)
+    env['PATH'] = path
+    return env
+
+
 def _update_java_version(current_java_version, current_java_home_version,
                          jvm_version=None, install_dir=None, cassandra_version=None, env=None,
                          for_build=False, info_message=None, os_env=None):
+
     # Internal variant accessible for tests
 
     if env is None:
         raise RuntimeError("env passed to _update_java_version must not be None")
 
+    if current_java_version and current_java_home_version is None:
+        raise RuntimeError("JAVA_HOME must be defined if java command is available on the PATH.")
+    if current_java_version and current_java_home_version != current_java_version:
+        raise RuntimeError("The version of java available on PATH {} does not match the Java version of the distribution provided via JAVA_HOME {}."
+                           .format(current_java_version, current_java_home_version))
+
     if cassandra_version is None and install_dir:
         cassandra_version = get_version_from_build(install_dir)
 
-    # conservative Java version defaults
-    # Cassandra versions 3.x and 2.x use the defaults
-    build_versions = [8]
-    run_versions = [8]
+    # Java versions supported by the Cassandra distribution
+    supported_versions = get_supported_jdk_versions(cassandra_version, install_dir, for_build, os_env if os_env else os.environ)
 
-    info(
-        '{}: current_java_version={}, current_java_home_version={}, jvm_version={}, for_build={}, cassandra_version={}, install_dir={}, env={}'
-        .format(info_message, current_java_version, current_java_home_version, jvm_version, for_build,
-                cassandra_version, install_dir, env))
+    # Java versions available in the current environment (JAVA_HOME, JAVAn_HOME)
+    available_versions = get_available_jdk_versions(env)
 
-    # this won't work with DSE versions
-    if cassandra_version >= '4.2':
-        if os.path.exists(os.path.join(install_dir, 'build.xml')):
-            build_versions = get_supported_jdk_versions(install_dir)
-            run_versions = get_supported_jdk_versions(install_dir)
-        else:
-            # binary installs we don't know which jdks are supported any more
-            build_versions = [current_java_version]
-            run_versions = [current_java_version]
+    # Intersection of supported and available Java versions
+    supported_available_versions = {v for v in supported_versions if v in available_versions}
 
-    if '4.0' <= cassandra_version < '4.2':
-        if not os_env:
-            os_env = os.environ
-        if 'CASSANDRA_USE_JDK11' not in os_env:
-            build_versions = [8, 11]
-            run_versions = [8, 11, 12, 13, 14, 15, 16, 17]
-        else:
-            build_versions = [11]
-            run_versions = [11]
-
-    versions = build_versions if for_build else run_versions
-
+    # Determine "jvm_version" - exact Java version to use if it was not explicitly provided
     if not jvm_version:
-        if current_java_version in versions:
-            jvm_version = current_java_version
-        else:
-            for version in versions:
-                if 'JAVA{}_HOME'.format(version) in env:
-                    jvm_version = version
-                    break
+        if current_java_version and current_java_version in supported_versions:
+            info('{}: Using the current Java {} available on PATH for the current invocation of Cassandra {}.'
+                 .format(info_message, current_java_version, cassandra_version))
+            # nothing to change in this case
+            return env
 
-        if jvm_version:
-            info('{}: using Java {} for the current invocation'
-                 .format(info_message, jvm_version))
+        elif current_java_home_version and current_java_home_version in supported_versions:
+            info('{}: Using the current Java {} available from JAVA_HOME for the current invocation of Cassandra {}.'
+                 .format(info_message, current_java_version, cassandra_version))
+            # just need to add JAVA_HOME/bin to the PATH
+            return update_path_in_env(env, env['JAVA_HOME'] + '/bin')
+
+        elif current_java_home_version and current_java_home_version not in supported_versions:
+            warning('{}: The current Java {} is not supported by Cassandra {} (supported versions: {}).'
+                    .format(info_message, current_java_version, cassandra_version, supported_versions))
+        else:
+            warning('{}: JAVA_HOME is not defined; CCM will try to find a suitable Java distribution among JAVAx_HOME env variables.')
+
+        if len(supported_available_versions) > 0:
+            info('{}: CCM has found {} Java distributions, the required Java version for Cassandra {} is {}.'.format(
+                info_message, str(available_versions), cassandra_version, supported_versions))
+            ref_version = current_java_home_version if current_java_home_version else max(supported_available_versions)
+            # sort by the absolute difference between the current java version and the supported version
+            # to use the closest version if the current version is not supported
+            jvm_version = sorted(supported_available_versions, key=lambda v: abs(v - ref_version))[0]
+
+        # No supported Java version available in the current env
+        else:
+            raise RuntimeError('{}: Cannot find any Java distribution for the current invocation. Available Java distributions: {}, required Java distributions: {}'
+                               .format(info_message, available_versions, supported_versions))
+
     else:
-        # Called proved an explicit Java version
         info('{}: Using explicitly requested Java version {} for the current invocation of Cassandra {}'
              .format(info_message, jvm_version, cassandra_version))
+        if jvm_version not in available_versions:
+            raise RuntimeError('{}: The explicitly requested Java version {} is not available in the current env.'
+                               .format(info_message, jvm_version))
+        if jvm_version not in supported_versions:
+            warning('{}: The explicitly requested Java version {} is not supported by Cassandra {}.'
+                    .format(info_message, jvm_version, cassandra_version))
 
-    # If the 'java' binary accessible via PATH points to a different Java version than the current JAVA_HOME,
-    # update it to point to the Java version of the 'java' binary accessible via PATH.
-    # Need to do this, because ccmlib.common.compile_version() uses the 'java' binary accessible via PATH via 'ant'.
-    if not jvm_version:
-        if current_java_home_version != current_java_version:
-            jvm_version = current_java_version
-            info('{}: Using Java {} for Cassandra {}, because the Java versions of java binary in PATH ({}) and '
-                 'JAVA_HOME ({}) did not match'.format(info_message, current_java_version, cassandra_version,
-                                                       current_java_version, current_java_home_version))
-        else:
-            jvm_version = current_java_version
-
-    if current_java_version != jvm_version or current_java_home_version != jvm_version:
-        new_java_home = 'JAVA{}_HOME'.format(jvm_version)
-        if new_java_home not in env:
-            raise RuntimeError("{}: You need to set JAVA{}_HOME to run Cassandra {}"
-                               .format(info_message, jvm_version, cassandra_version))
-        env['JAVA_HOME'] = env[new_java_home]
-        env['PATH'] = '{}/bin:{}'.format(env[new_java_home], env['PATH'] if 'PATH' in env else '')
-    return env
+    env['JAVA_HOME'] = env[available_versions[jvm_version]]
+    return update_path_in_env(env, env['JAVA_HOME'] + '/bin')
 
 
 def assert_jdk_valid_for_cassandra_version(cassandra_version):

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -72,13 +72,13 @@ class DseCluster(Cluster):
     def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None,derived_cassandra_version=None):
         return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, derived_cassandra_version=derived_cassandra_version)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False, jvm_version=None):
         if jvm_args is None:
             jvm_args = []
         marks = {}
         for node in self.nodelist():
             marks[node] = node.mark_log()
-        started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options, quiet_start=quiet_start, allow_root=allow_root, timeout=180)
+        started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options, quiet_start=quiet_start, allow_root=allow_root, timeout=180, jvm_version=jvm_version)
         self.start_opscenter()
         if self._misc_config_options.get('enable_aoss', False):
             self.wait_for_any_log('AlwaysOn SQL started', 600, marks=marks)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -239,7 +239,7 @@ class Node(object):
         env = common.make_cassandra_env(self.get_install_dir(), self.get_path(), update_conf)
         env = common.update_java_version(jvm_version=None,
                                          install_dir=self.get_install_dir(),
-                                         cassandra_version=self.cluster.cassandra_version(),
+                                         cassandra_version=self.get_cassandra_version(),
                                          env=env,
                                          info_message=self.name)
         for (key, value) in self.__environment_variables.items():

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,11 +1,16 @@
+import os
 import sys
+import tempfile
 import time
+from distutils.version import LooseVersion  # pylint: disable=import-error, no-name-in-module
+from pathlib import Path
 
+import requests
 from six import StringIO
 
 import ccmlib
 from ccmlib.cluster import Cluster
-from ccmlib.common import _update_java_version
+from ccmlib.common import _update_java_version, get_supported_jdk_versions_from_dist, get_supported_jdk_versions, get_available_jdk_versions
 from ccmlib.node import NodeError
 from . import TEST_DIR, ccmtest
 from distutils.version import LooseVersion  # pylint: disable=import-error, no-name-in-module
@@ -16,224 +21,181 @@ CLUSTER_PATH = TEST_DIR
 
 
 class TestUpdateJavaVersion(ccmtest.Tester):
+    env = dict()
+    temp_dir = None
+    all_versions = ['2.2', '3.0', '3.1', '3.11', '4.0', '4.1', '5.0', '5.1']
+
+    # prepare for tests
+    def setUp(self):
+        # create a directory in temp location
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+        # create fake java distribution directories for 7, 8, 11, 17, and 21 in temp directory
+        for jvm_version in [7, 8, 11, 17, 21]:
+            path = self.temp_dir.name + '/java{}'.format(jvm_version)
+            Path(path + '/bin').mkdir(parents=True, exist_ok=True)
+            # create java executable with a script returning java version
+            full_version = '{}.0.{}'.format(jvm_version, jvm_version * 2)
+            build_version = jvm_version * 3
+            with open(path + '/bin/java', 'w') as f:
+                f.write('#!/bin/bash\n')
+                # there must be an only parameter '-version' in the command line
+                f.write('if [ "$1" != "-version" ]; then\n')
+                f.write('  exit 1\n')
+                f.write('fi\n')
+                f.write('echo \'openjdk version "{}" 2023-04-18\'\n'.format(full_version))
+                f.write('echo \'OpenJDK Runtime Environment Temurin-{}+{} (build {}+{})\'\n'.format(full_version, build_version, full_version, build_version))
+                f.write('echo \'OpenJDK 64-Bit Server VM Temurin-{}+{} (build {}+{}, mixed mode)\'\n'.format(full_version, build_version, full_version, build_version))
+            # make the script executable
+            os.chmod(path + '/bin/java', 0o755)
+            self.env['JAVA{}_HOME'.format(jvm_version)] = path
+
+    def _make_cassandra_install_dir(self, git_branch, is_source_dist):
+        dist_dir = '{}/cassandra/{}'.format(self.temp_dir.name, git_branch)
+        Path(dist_dir + "/bin").mkdir(parents=True, exist_ok=True)
+
+        if is_source_dist:
+            if not Path(dist_dir + '/build.xml').exists():
+                with open(dist_dir + '/build.xml', 'w') as f:
+                    r = requests.get('https://raw.githubusercontent.com/apache/cassandra/{}/build.xml'.format(git_branch))
+                    f.write(r.text)
+        else:
+            if Path(dist_dir + '/build.xml').exists():
+                os.remove(dist_dir + '/build.xml')
+
+        if not Path(dist_dir + '/bin/cassandra.in.sh').exists():
+            with open(dist_dir + '/bin/cassandra.in.sh', 'w') as f:
+                r = requests.get('https://raw.githubusercontent.com/apache/cassandra/{}/bin/cassandra.in.sh'.format(git_branch))
+                f.write(r.text)
+
+        return dist_dir
+
+    def _make_env(self, java_home_version=None, java_path_version=None, include_homes=None):
+        env = dict()
+        if include_homes:
+            for v in include_homes:
+                key = 'JAVA{}_HOME'.format(v)
+                env[key] = self.env[key]
+        else:
+            env = self.env.copy()
+        if java_home_version is not None:
+            env['JAVA_HOME'] = self.env['JAVA{}_HOME'.format(java_home_version)]
+        if java_path_version is not None:
+            env['PATH'] = self.env['JAVA{}_HOME'.format(java_path_version)] + "/bin:/some/path"
+        return env
+
+    def _check_env(self, result_env, expected_java_version):
+        self.assertIn('JAVA_HOME', result_env)
+        self.assertIn('PATH', result_env)
+        self.assertEqual(self.env['JAVA{}_HOME'.format(expected_java_version)], result_env['JAVA_HOME'])
+        self.assertIn('{}/bin'.format(self.env['JAVA{}_HOME'.format(expected_java_version)]), result_env['PATH'])
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_get_supported_jdk_versions_from_dist(self):
+        # we cannot assert anything about trunk except that we can figure out some versions
+        self.assertIsNotNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('trunk', False)))
+        self.assertIsNotNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('trunk', True)))
+
+        # some commit of Cassandra 5.1
+        self.assertEquals(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', False)), [11, 17])
+        self.assertEquals(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', True)), [11, 17])
+
+        self.assertIsNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-5.0', False)))
+        self.assertEquals(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-5.0', True)), [11, 17])
+
+        self.assertIsNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-4.1', False)))
+        self.assertIsNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-4.1', True)))
+
+    def test_supported_jdk_versions(self):
+        for cassandra_version in [None, '2.2', '3.0', '3.1', '4.0', '4.1']:
+            self.assertIn(8, get_supported_jdk_versions(cassandra_version, None, False, {'key': 'value'}))
+            self.assertIn(8, get_supported_jdk_versions(cassandra_version, None, True, {'key': 'value'}))
+
+        for cassandra_version in ['4.0', '4.1', '5.0', '5.1']:
+            self.assertNotIn(8, get_supported_jdk_versions(cassandra_version, None, False, {'CASSANDRA_USE_JDK11': 'true'}))
+            self.assertNotIn(8, get_supported_jdk_versions(cassandra_version, None, True, {'CASSANDRA_USE_JDK11': 'true'}))
+
+        for cassandra_version in ['4.0', '4.1', '5.0', '5.1']:
+            self.assertIn(11, get_supported_jdk_versions(cassandra_version, None, False, {'key': 'value'}))
+            self.assertIn(11, get_supported_jdk_versions(cassandra_version, None, True, {'key': 'value'}))
+
+        for cassandra_version in [None, '2.2', '3.0', '3.11']:
+            self.assertNotIn(11, get_supported_jdk_versions(cassandra_version, None, False, {'key': 'value'}))
+            self.assertNotIn(11, get_supported_jdk_versions(cassandra_version, None, True, {'key': 'value'}))
+
+        for cassandra_version in ['5.0', '5.1']:
+            self.assertIn(17, get_supported_jdk_versions(cassandra_version, None, False, {'key': 'value'}))
+            self.assertIn(17, get_supported_jdk_versions(cassandra_version, None, True, {'key': 'value'}))
+
+        for cassandra_version in [None, '2.2', '3.0', '3.11', '4.0', '4.1']:
+            self.assertNotIn(17, get_supported_jdk_versions(cassandra_version, None, False, {'key': 'value'}))
+            self.assertNotIn(17, get_supported_jdk_versions(cassandra_version, None, True, {'key': 'value'}))
+
+    def test_get_available_jdk_versions(self):
+        self.assertDictEqual(get_available_jdk_versions(self._make_env()), {7: 'JAVA7_HOME', 8: 'JAVA8_HOME', 11: 'JAVA11_HOME', 17: 'JAVA17_HOME', 21: 'JAVA21_HOME'})
+        self.assertDictEqual(get_available_jdk_versions(self._make_env(java_home_version=8, include_homes=[11, 17])), {8: 'JAVA_HOME', 11: 'JAVA11_HOME', 17: 'JAVA17_HOME'})
+
+    def _test_java_selection(self, expected_version, path_version, home_version, explicit_version, cassandra_versions, available_homes=None):
+        for cassandra_version in cassandra_versions:
+            result_env = _update_java_version(current_java_version=path_version, current_java_home_version=home_version,
+                                              jvm_version=explicit_version, install_dir=None, cassandra_version=LooseVersion(cassandra_version),
+                                              env=self._make_env(java_home_version=home_version, java_path_version=path_version, include_homes=available_homes),
+                                              for_build=True, info_message='test_java_selection_{}'.format(cassandra_version), os_env={'key': 'value'})
+            self._check_env(result_env, expected_version)
+
+    def _test_java_selection_fail(self, expected_failure_regexp, path_version, home_version, explicit_version, cassandra_versions, available_homes=None):
+        for cassandra_version in cassandra_versions:
+            self.assertRaisesRegex(RuntimeError, expected_failure_regexp, _update_java_version,
+                                   path_version, home_version, explicit_version, None, LooseVersion(cassandra_version),
+                                   self._make_env(java_home_version=home_version, java_path_version=path_version, include_homes=available_homes),
+                                   True, 'test_java_selection_fail_{}'.format(cassandra_version), {'key': 'value'})
+
     def test_update_java_version(self):
-        # Tests for C*-4.0 (Java 8 or 11 or newer)
+        # use the highest supported version if there is no current Java command available
+        self._test_java_selection(8, None, None, None, ['2.2', '3.0', '3.11'])
+        self._test_java_selection(11, None, None, None, ['4.0', '4.1'])
+        self._test_java_selection(17, None, None, None, ['5.0', '5.1'])
 
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_1',
-                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
-                          'PATH': '/some/bin'},
-                         result_env)
+        self._test_java_selection(8, None, None, None, ['4.0', '4.1'], available_homes=[8])
+        self._test_java_selection(11, None, None, None, ['4.0', '4.1'], available_homes=[8, 11])
+        self._test_java_selection(11, None, None, None, ['4.0', '4.1'], available_homes=[8, 11])
 
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_2',
-                                          os_env={'X': '1'})
-        self.assertEqual({'PATH': '/some/bin'},
-                         result_env)
+        # use the current Java version if it is supported, otherwise use the closest possible Java version
+        # current is 8
+        self._test_java_selection(8, 8, 8, None, ['2.2', '3.0', '3.11', '4.0', '4.1'])
+        self._test_java_selection(11, 8, 8, None, ['5.0', '5.1'])
+        # current is 11
+        self._test_java_selection(8, 11, 11, None, ['2.2', '3.0', '3.11'])
+        self._test_java_selection(11, 11, 11, None, ['4.0', '4.1', '5.0', '5.1'])
+        # current is 17
+        self._test_java_selection(8, 17, 17, None, ['2.2', '3.0', '3.11'])
+        self._test_java_selection(11, 17, 17, None, ['4.0', '4.1'])
+        self._test_java_selection(17, 17, 17, None, ['5.0', '5.1'])
 
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_3',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
-                          'PATH': '/some/bin'},
-                         result_env)
+        # same as above, but now there is only JAVA_HOME defined and no Java command on the PATH
+        self._test_java_selection(8, None, 8, None, ['2.2', '3.0', '3.11', '4.0', '4.1'])
+        self._test_java_selection(11, None, 8, None, ['5.0', '5.1'])
+        self._test_java_selection(8, None, 11, None, ['2.2', '3.0', '3.11'])
+        self._test_java_selection(11, None, 11, None, ['4.0', '4.1', '5.0', '5.1'])
+        self._test_java_selection(8, None, 17, None, ['2.2', '3.0', '3.11'])
+        self._test_java_selection(11, None, 17, None, ['4.0', '4.1'])
+        self._test_java_selection(17, None, 17, None, ['5.0', '5.1'])
 
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_4',
-                                          os_env={'X': '1'})
-        self.assertEqual({'PATH': '/some/bin'},
-                         result_env)
+        # set explicit version should override everything
+        self._test_java_selection(21, None, None, 21, self.all_versions)
+        self._test_java_selection(21, 8, 8, 21, self.all_versions)
+        self._test_java_selection(21, 11, 11, 21, self.all_versions)
+        self._test_java_selection(21, 17, 17, 21, self.all_versions)
 
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_5',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin'},
-                         result_env)
+        # fail if the required Java version is not available
+        self._test_java_selection_fail("Cannot find any Java distribution for the current invocation", None, None, None, self.all_versions, available_homes=[21])
+        self._test_java_selection_fail("The explicitly requested Java version 11 is not available in the current env", None, None, 11, self.all_versions, available_homes=[8])
 
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_6',
-                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_7',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_8',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_9',
-                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=8,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_10',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=11,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_4.0_11',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=8, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('4.0'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'PATH': '/some/bin:/opt/foo/java_home11/bin',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11'},
-                                          for_build=False, info_message='test_update_java_version_4.0_12',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin:/opt/foo/java_home11/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        # Tests for pre-C*-4.0 (Java 8 only)
-
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_3.11_1',
-                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home',
-                          'PATH': '/some/bin'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_3.11_2',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11',
-                          'PATH': '/some/bin'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_3.11_3',
-                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'PATH': '/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=11, current_java_home_version=11, jvm_version=None,
-                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home11',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_3.11_4',
-                                          os_env={'CASSANDRA_USE_JDK11': 'true'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home8',
-                          'PATH': '/opt/foo/java_home8/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
-
-        result_env = _update_java_version(current_java_version=8, current_java_home_version=8, jvm_version=11,
-                                          install_dir=None, cassandra_version=LooseVersion('3.11'),
-                                          env={'JAVA_HOME': '/opt/foo/java_home8',
-                                               'JAVA8_HOME': '/opt/foo/java_home8',
-                                               'JAVA11_HOME': '/opt/foo/java_home11',
-                                               'PATH': '/some/bin'},
-                                          for_build=True, info_message='test_update_java_version_3.11_5',
-                                          os_env={'X': '1'})
-        self.assertEqual({'JAVA_HOME': '/opt/foo/java_home11',
-                          'PATH': '/opt/foo/java_home11/bin:/some/bin',
-                          'JAVA8_HOME': '/opt/foo/java_home8',
-                          'JAVA11_HOME': '/opt/foo/java_home11'},
-                         result_env)
+        # fail if home and path are inconsistent
+        self._test_java_selection_fail("The version of java available on PATH 8 does not match the Java version of the distribution provided via JAVA_HOME 11", path_version=8, home_version=11, explicit_version=None, cassandra_versions=self.all_versions)
+        self._test_java_selection_fail("JAVA_HOME must be defined if java command is available on the PATH", path_version=8, home_version=None, explicit_version=None, cassandra_versions=self.all_versions)
 
 
 class TestCCMLib(ccmtest.Tester):
@@ -330,6 +292,7 @@ class TestCCMLib(ccmtest.Tester):
                                          binary_interface=('127.0.0.3', 9042))
         with self.assertRaisesRegexp(ccmlib.common.ArgumentError, 'Please specify the DC this node should be added to'):
             self.cluster.add(node3, is_seed=False)
+
 
 class TestRunCqlsh(ccmtest.Tester):
 


### PR DESCRIPTION
The logic works as follows:

1. Look for available Java versions in the env - figure out versions of Java located at `JAVA_HOME` and all `JAVAx_HOME` env vars (actually execute `java -version` to check)

2. Figure out supported Java versions by Cassandra distribution - for Cassandra 5.1+ binary distribution the supported Java versions can be read from `cassandra.in.sh` and for Cassandra 5.0+ source distribution the supported Java versions can be read from `build.xml`. For other Cassandra versions, the supported Java versions are hardcoded in CCM

3. If Java version is explicitly provided - use it if it is available (see 1), warn if it is not supported by Cassandra

4. If `JAVA_HOME` is defined, use that Java distribution if it is supported by Cassandra distribution; if it is not supported, select the closest supported (see 2) and available (see 1) Java version

5. If `JAVA_HOME` is not defined, use the highest supported (see 2) and available (see 1) Java version

Also, if Java is available on the `PATH`, `JAVA_HOME` must be defined as well and both must refer to the same Java version. Fail if Java is available on the `PATH` and there is no `JAVA_HOME` or if `JAVA_HOME` refers a different Java version than Java defined on the `PATH`.

Also,
- Added `--jvm-version` option to the cluster and node start commands.
- Fixed one problem with Java selection for tools run on the upgraded node