### PR TITLE
Fix confused env usages

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -824,8 +824,8 @@ def invalidate_cache():
     rmdirs(os.path.join(get_default_path(), 'repository'))
 
 
-def get_jdk_version_int(process='java'):
-    jdk_version_str = get_jdk_version(process)
+def get_jdk_version_int(process='java', env=None):
+    jdk_version_str = get_jdk_version(process, env)
     if jdk_version_str is None:
         return None
     jdk_version = float(jdk_version_str)
@@ -834,14 +834,14 @@ def get_jdk_version_int(process='java'):
     return jdk_version
 
 
-def get_jdk_version(process='java'):
+def get_jdk_version(process='java', env=None):
     """
     Retrieve the Java version as reported in the quoted string returned
     by invoking 'java -version'.
     Works for Java 1.8, Java 9 and newer.
     """
     try:
-        version = subprocess.check_output([process, '-version'], stderr=subprocess.STDOUT)
+        version = subprocess.check_output([process, '-version'], stderr=subprocess.STDOUT, env=env)
     except OSError:
         info("Could not find {}.".format(process))
         return None
@@ -951,7 +951,7 @@ def update_java_version(jvm_version=None, install_dir=None, cassandra_version=No
 
     env = env if env else os.environ
 
-    current_java_version = get_jdk_version_int()
+    current_java_version = get_jdk_version_int(env=env)
     current_java_home_version = get_jdk_version_int(
         '{}/bin/java'.format(env['JAVA_HOME'])) if 'JAVA_HOME' in env else current_java_version
     # Code to ensure that we start C* using the correct Java version.
@@ -1045,8 +1045,8 @@ def _update_java_version(current_java_version, current_java_home_version,
     return update_path_in_env(env, env['JAVA_HOME'] + '/bin')
 
 
-def assert_jdk_valid_for_cassandra_version(cassandra_version):
-    jdk_version = float(get_jdk_version())
+def assert_jdk_valid_for_cassandra_version(cassandra_version, env=None):
+    jdk_version = float(get_jdk_version(env=env))
     if cassandra_version >= '4.2':
         if jdk_version < 11 or 11 < jdk_version < 17 or 17 < jdk_version:
             error('Cassandra {} requires Java 11 or Java 17, found Java {}'.format(cassandra_version, jdk_version))

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -151,6 +151,7 @@ class Node(object):
         self.__environment_variables = environment_variables or {}
         self.__environment_variables = self.__environment_variables.copy()
         self.__original_java_home = None
+        self.__original_path = None
         self.__conf_updated = False
 
         if derived_cassandra_version:
@@ -848,9 +849,14 @@ class Node(object):
         if not self.__original_java_home:
             # Save the "original" JAVA_HOME + PATH to restore it.
             self.__original_java_home = os.environ['JAVA_HOME']
+            self.__original_path = os.environ['PATH']
+            logger.info("Saving original JAVA_HOME={} PATH={}".format(self.__original_java_home, self.__original_path))
         else:
             # Restore the "original" JAVA_HOME + PATH to restore it.
             env['JAVA_HOME'] = self.__original_java_home
+            env['PATH'] = self.__original_path
+            logger.info("Restoring original JAVA_HOME={} PATH={}".format(self.__original_java_home, self.__original_path))
+
         env = common.update_java_version(jvm_version=jvm_version,
                                          install_dir=self.get_install_dir(),
                                          cassandra_version=self.get_cassandra_version(),
@@ -862,7 +868,7 @@ class Node(object):
             self.__environment_variables[k] = env[k]
 
         common.info("Starting {} with JAVA_HOME={} java_version={} cassandra_version={}, install_dir={}"
-                    .format(self.name, env['JAVA_HOME'], common.get_jdk_version_int(),
+                    .format(self.name, env['JAVA_HOME'], common.get_jdk_version_int(env=env),
                             self.get_cassandra_version(), self.get_install_dir()))
 
         # In case we are restarting a node

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -409,7 +409,7 @@ def compile_version(version, target_dir, verbose=False):
         else:
             # No gradle, use ant
             cmd = [platform_binary('ant'), 'jar']
-            if get_jdk_version_int() >= 11:
+            if get_jdk_version_int(env=env) >= 11:
                 cmd.append('-Duse.jdk11=true')
         while attempt < 3 and ret_val != 0:
             if attempt > 0:


### PR DESCRIPTION
1. Before/after starting a node, only JAVA_HOME was stored/restored which could be responsible for divergences between Java version on PATH and JAVA_HOME
2. Method which calls 'java' from the PATH to check its version didn't take into account the updated env