### PR TITLE
Donation to Apache Cassandra and ASF

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: CI
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ccm.egg-info/
 dse_creds.txt
 .eggs/
 junit.xml
+/nbproject/

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,61 @@
+Apache Cassandra Cluster Manager
+Copyright 2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+This product originates, before git sha
+cc8cb98b29f68d12c8b5fa093a33dc3b346873b3, from software from DataStax
+and other individual contributors.
+
+Non-DataStax contributors are listed below. Those marked with
+asterisk have agreed to donate (copyright assign) their contributions to the
+Apache Software Foundation, signing CLAs when appropriate.
+
+Kishan Karunaratne <kishan@karu.io>
+Lucas Meneghel @lmr
+Joaquin Casares @joaquincasares
+Andrew Hust @nutbunnies
+Jaume Marhuenda <jaumemarhuenda@gmail.com>
+Daniel Compton <desk+github@danielcompton.net> *
+??? @steveandwang
+Byron Clark <byron@theclarkfamily.name> *
+Thibault Charbonnier @thibaultcha
+Greg Bestland @GregBestland
+??? @c-kodman
+Sandeep Tamhankar @stamhankar999
+Tomek Bujok @tombujok
+Pekka Enberg <penberg@iki.fi>
+Brian Weck @bweck
+Dimitri Krassovski <labria@startika.com> *
+??? @nattochaduke-yahoo
+??? @pydeveloper94
+Geet Kumar @gkumar7
+??? @scharron
+Eric Stevens @MightyE *
+Rui Chen <rui@hexpunks.org>
+??? @ezacks-barracuda
+Tetsuya Morimoto @t2y
+Casey Marshall @csmlyve
+??? @jillichrome
+??? @ekooiker *
+Chris Bargren <cbargren@gmail.com>
+Xian Yi Teng <xytxytxyt@gmail.com>
+Stefano Ortolani @ostefano *
+Cormoran <cormoran707@gmail.com>
+??? @hatokani2
+??? @jeremycnf
+Samuel Roberts @sproberts92
+Alexei Maridashvili <alexei.maridashvili@gmail.com> *
+Michael Hamm <mikejameshamm@gmail.com> *
+Lerh Low @juiceblender
+Peter Palaga <ppalaga@redhat.com> *
+Hannu Kröger @hkroger *
+Jacob Fenwick <jacob.fenwick@gmail.com>
+Ulises Cervino Beresi <ulises.cervino@gmail.com> *
+Jack Kingsman @jkingsman *
+Yasuharu Goto <matope.ono@gmail.com>
+David Sauer <david@nur-mal-so-am-ran.de>
+Nick Bailey <nickmbailey@gmail.com> *
+Alex Popescu @al3xandru

--- a/README-CASSANDRA-17379.md.md
+++ b/README-CASSANDRA-17379.md.md
@@ -1,0 +1,34 @@
+CCM (Cassandra Cluster Manager)
+CASSANDRA-17379 README
+====================================================
+
+
+---- 
+ 
+
+
+WARNING - CCM configuration changes using updateconf does not happen according to CASSANDRA-17379
+-------------------------------------------------------------------------------------------------
+
+After CASSANDRA-15234, to support the Python upgrade tests CCM updateconf is replacing
+new key name and value in case the old key name and value is provided.
+For example, if you add to config `permissions_validity_in_ms`, it will replace
+`permissions_validity` in default cassandra.yaml
+This was needed to ensure correct overloading as CCM cassandra.yaml has keys
+sorted lexicographically. CASSANDRA-17379 was opened to improve the user experience
+and deprecate the overloading of parameters in cassandra.yaml. In CASSANDRA 4.1+, by default,
+we refuse starting Cassandra with a config containing both old and new config keys for the
+same parameter. Start Cassandra with `-Dcassandra.allow_new_old_config_keys=true` to override.
+For historical reasons duplicate config keys in cassandra.yaml are allowed by default, start
+Cassandra with `-Dcassandra.allow_duplicate_config_keys=false` to disallow this. Please note
+that key_cache_save_period, row_cache_save_period, counter_cache_save_period will be affected
+only by `-Dcassandra.allow_duplicate_config_keys`. Ticket CASSANDRA-17949 was opened to decide
+the future of CCM updateconf post CASSANDRA-17379, until then - bear in mind that old replace
+new parameters' in cassandra.yaml when using updateconf even if
+`-Dcassandra.allow_new_old_config_keys=false` is set by default.
+
+TLDR Do not exercise overloading of parameters in CCM if possible. Also, the mentioned changes
+are done only in master branch. Probably the best way to handle cassandra 4.1 in CCM at this
+point is to set `-Dcassandra.allow_new_old_config_keys=false` and
+`-Dcassandra.allow_duplicate_config_keys=false`
+to prohibit any kind of overloading when using CCM master and CCM released versions

--- a/README.md
+++ b/README.md
@@ -1,35 +1,6 @@
 CCM (Cassandra Cluster Manager)
 ====================================================
 
-WARNING - CCM configuration changes using updateconf does not happen according to CASSANDRA-17379
--------------------------------------------------------------------------------------------------
-
-After CASSANDRA-15234, to support the Python upgrade tests CCM updateconf is replacing
-new key name and value in case the old key name and value is provided.  
-For example, if you add to config `permissions_validity_in_ms`, it will replace 
-`permissions_validity` in default cassandra.yaml 
-This was needed to ensure correct overloading as CCM cassandra.yaml has keys 
-sorted lexicographically. CASSANDRA-17379 was opened to improve the user experience 
-and deprecate the overloading of parameters in cassandra.yaml. In CASSANDRA 4.1+, by default, 
-we refuse starting Cassandra with a config containing both old and new config keys for the
-same parameter. Start Cassandra with `-Dcassandra.allow_new_old_config_keys=true` to override.
-For historical reasons duplicate config keys in cassandra.yaml are allowed by default, start 
-Cassandra with `-Dcassandra.allow_duplicate_config_keys=false` to disallow this. Please note
-that key_cache_save_period, row_cache_save_period, counter_cache_save_period will be affected 
-only by `-Dcassandra.allow_duplicate_config_keys`. Ticket CASSANDRA-17949 was opened to decide
-the future of CCM updateconf post CASSANDRA-17379, until then - bear in mind that old replace 
-new parameters' in cassandra.yaml when using updateconf even if 
-`-Dcassandra.allow_new_old_config_keys=false` is set by default. 
-
-TLDR Do not exercise overloading of parameters in CCM if possible. Also, the mentioned changes
-are done only in master branch. Probably the best way to handle cassandra 4.1 in CCM at this 
-point is to set `-Dcassandra.allow_new_old_config_keys=false` and 
-`-Dcassandra.allow_duplicate_config_keys=false` 
-to prohibit any kind of overloading when using CCM master and CCM released versions
-
-
-CCM (Cassandra Cluster Manager)
-====================================================
 
 A script/library to create, launch and remove an Apache Cassandra cluster on
 localhost.
@@ -391,6 +362,3 @@ how to use ccmlib follows:
     # after the test, you can leave the cluster running, you can stop all nodes
     # using cluster.stop() but keep the data around (in CLUSTER_PATH/test), or
     # you can remove everything with cluster.remove()
-
---
-Sylvain Lebresne <sylvain@datastax.com>

--- a/ccm
+++ b/ccm
@@ -1,4 +1,20 @@
 #!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import sys

--- a/ccmlib/__init__.py
+++ b/ccmlib/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # ccm clusters
 from __future__ import absolute_import
 

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 from __future__ import absolute_import
 

--- a/ccmlib/cmds/__init__.py
+++ b/ccmlib/cmds/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 from __future__ import absolute_import
 

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 from __future__ import absolute_import
 

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 from __future__ import absolute_import
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 #
 # Cassandra Cluster Management lib
 #

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # ccm clusters
 
 from __future__ import absolute_import

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # ccm node
 from __future__ import absolute_import, with_statement
 

--- a/ccmlib/extension.py
+++ b/ccmlib/extension.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 PRE_CLUSTER_START_HOOKS = []
 POST_CLUSTER_START_HOOKS = []
 PRE_CLUSTER_STOP_HOOKS = []

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # ccm node
 from __future__ import absolute_import, with_statement
 

--- a/ccmlib/remote.py
+++ b/ccmlib/remote.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 #
 # Remote execution helper functionality for executing CCM commands on a remote
 # machine with CCM installed

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # downloaded sources handling
 from __future__ import absolute_import, division, with_statement
 

--- a/misc/Vagrantfile
+++ b/misc/Vagrantfile
@@ -1,4 +1,20 @@
 # -*- mode: ruby -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # vi: set ft=ruby :
 
 # Configure defaults and/or allow to be overridden

--- a/misc/ccm-completion.bash
+++ b/misc/ccm-completion.bash
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 ##############################################################################
 # ccm-completion.bash
 #

--- a/misc/ccm-macos.bash
+++ b/misc/ccm-macos.bash
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 CLUSTER_NAME=${CLUSTER_NAME:-test}
 NUM_NODES=${NUM_NODES:-3}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 pyYaml
 six >=1.4.1
 psutil

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 from platform import system
 from shutil import copyfile

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import sys
 
 

--- a/tests/ccmtest.py
+++ b/tests/ccmtest.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import os
 from unittest import TestCase
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import os
 import pytest
 import shutil

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 mock==5.1.0
 pytest==8.2.1
 requests==2.32.2

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import unittest
 from mock import patch
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import os
 import sys
 import tempfile
@@ -100,11 +117,11 @@ class TestUpdateJavaVersion(ccmtest.Tester):
         self.assertIsNotNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('trunk', True)))
 
         # some commit of Cassandra 5.1
-        self.assertEquals(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', False)), [11, 17])
-        self.assertEquals(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', True)), [11, 17])
+        self.assertEqual(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', False)), [11, 17])
+        self.assertEqual(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('6bae4f76fb043b4c3a3886178b5650b280e9a50b', True)), [11, 17])
 
         self.assertIsNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-5.0', False)))
-        self.assertEquals(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-5.0', True)), [11, 17])
+        self.assertEqual(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-5.0', True)), [11, 17])
 
         self.assertIsNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-4.1', False)))
         self.assertIsNone(get_supported_jdk_versions_from_dist(self._make_cassandra_install_dir('cassandra-4.1', True)))


### PR DESCRIPTION
Reassignment of copyright, where approved, and relicensing.
New repository will be github.com/apache/cassandra-ccm


ref: https://github.com/riptano/ccm/issues/773 