### PR TITLE
Update snitch/location config selection

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -275,7 +275,12 @@ class Cluster(object):
             self.use_vnodes = use_vnodes
 
         if isinstance(nodes, list):
+            # We set both the legacy and modern config options here, although they are mutually exclusive. When we
+            # actually finalise the config for nodes in the cluster we select which one to keep based on the supplied
+            # yaml file. One of the two keys must be present in the yaml, so we retain whichever that is.
             self.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.PropertyFileSnitch'})
+            self.set_configuration_options(values={'initial_location_provider': 'org.apache.cassandra.locator.TopologyFileLocationProvider'})
+
             node_count = 0
             i = 0
             for c in nodes:

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -275,11 +275,10 @@ class Cluster(object):
             self.use_vnodes = use_vnodes
 
         if isinstance(nodes, list):
-            # We set both the legacy and modern config options here, although they are mutually exclusive. When we
-            # actually finalise the config for nodes in the cluster we select which one to keep based on the supplied
-            # yaml file. One of the two keys must be present in the yaml, so we retain whichever that is.
+            # We set PFS here as a "marker" that we need to read cassandra-topology.properties for this cluster
+            # This is then checked in node.py::_update_yaml where we check if initial_location_provider is set in
+            # the yaml (indicating that modern config is supported) and we set TopologyFileLocationProvider if so
             self.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.PropertyFileSnitch'})
-            self.set_configuration_options(values={'initial_location_provider': 'org.apache.cassandra.locator.TopologyFileLocationProvider'})
 
             node_count = 0
             i = 0

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1760,11 +1760,20 @@ class Node(object):
         if self.cluster.partitioner:
             data['partitioner'] = self.cluster.partitioner
 
+
         # Get a map of combined cluster and node configuration with the node
         # configuration taking precedence.
         full_options = common.merge_configuration(
             self.cluster._config_options,
             self.__config_options, delete_empty=False)
+
+        if 'initial_location_provider' in data:
+            common.debug("yaml contained initial_location_provider, removing endpoint_snitch from merged config")
+            full_options.pop('endpoint_snitch', None)
+        elif 'endpoint_snitch' in data:
+            common.debug("yaml contained endpoint_snitch, removing initial_location_provider from merged config")
+            full_options.pop('initial_location_provider', None)
+            full_options.pop('node_proximity', None)
 
         # Merge options with original yaml data.
         data = common.merge_configuration(data, full_options)


### PR DESCRIPTION
CASSANDA-19488 deprecates IEndpointSnitch and replaces it with InitialLocationProvider and NodeProximity classes. In Cassandra, the default yaml config retains the endpoint_snitch setting, whereas the alternative cassandra_latest yaml specifies the new options. CCM injects PropertyFileSnitch into config for multi datacenter clusters, but this is problematic as the old and new config options are mutually exclusive.

This patch injects both the old and new settings into config when the cluster is populated, then removes whichever one was not present in the original yaml once it has been loaded. This allows dtests to run with both the legacy and latest configs and exercises both code paths.